### PR TITLE
fix tile server example url in docker

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -9,7 +9,7 @@ services:
       DATABASE_URL: mysql://user:password@host:3306/database_name
       START_LAT: 0
       START_LON: 0
-      TILE_SERVER: "https://{s}.basemaps.cartocdn.com/rastertiles/voyager_labels_under/{z}/{x}/{y}{r}"
+      TILE_SERVER: "https://{s}.basemaps.cartocdn.com/rastertiles/voyager_labels_under/{z}/{x}/{y}{r}.png"
       PORT: 8080
     ports:
       - "9095:8080"


### PR DESCRIPTION
without that suffix it does not work