### PR TITLE
Increase max accepted payload size to 10MB

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -37,6 +37,8 @@ async fn main() -> std::io::Result<()> {
         App::new()
             .app_data(web::Data::new(pool.clone()))
             .app_data(web::Data::new(scanner_type.clone()))
+            // increase max payload size to 10MB
+            .app_data(web::JsonConfig::default().limit(10_485_760))
             .wrap(middleware::Logger::new("%s | %r - %b bytes in %D ms (%a)"))
             .service(
                 web::scope("api")


### PR DESCRIPTION
Hello,

I increased the max payload size on the APIs from 2MB to 10MB. This allows to send more points to the APIs. Is this value ok with you? 
I tested locally, and I no longer receive a http 413 error code when posting 50k points.

Thanks.

PS: I don't know anything about Rust, so excuse me if I've made a mistake