### PR TITLE
Add docker limits example

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '2'
 services:
   koji:
     image: ghcr.io/turtiesocks/koji:main
@@ -12,5 +12,8 @@ services:
       TILE_SERVER: "https://{s}.basemaps.cartocdn.com/rastertiles/voyager_labels_under/{z}/{x}/{y}{r}.png"
       PORT: 8080
       SCANNER_TYPE: "rdm"
+    #mem_limit: 2048G
+    #mem_reservation: 256M
+    #cpus: 2 
     ports:
       - "9095:8080"


### PR DESCRIPTION
Revert to docker-compose version 2.0 since that's the official method of imposing limits on docker hosts. If users are familiar with Swarm it should be trivial to swap back to version 3.0. Koji will by default use 100% of all resources on a host which is going to result in a bad time for users that run this on their single VM with RDM, Database, Discord alerts, etc. Capping the speed a little is likely an overall win for _most_ users.

Disabling the limit by default.