### PR TITLE
improve bootstrapping

### DIFF
--- a/client/src/services/fetches.ts
+++ b/client/src/services/fetches.ts
@@ -205,7 +205,6 @@ export async function clusteringRouting(): Promise<FeatureCollection> {
         }
         const json = await res.json()
         const fetch_time = Date.now() - startTime
-        console.log({ fenceRef })
         setStatic('loading', (prev) => ({
           ...prev,
           [fenceRef

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "algorithms"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "geo",
  "geohash",

--- a/server/algorithms/Cargo.toml
+++ b/server/algorithms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "algorithms"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
- Resolves #84
- Use references in more places to reduce cloning
- Account for interiors as well
- Loop interiors to accurately check each one