### PR TITLE
add fort category

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "koji",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Tool to make RDM routes",
   "main": "server/dist/index.js",
   "author": "TurtIeSocks <58572875+TurtIeSocks@users.noreply.github.com>",

--- a/client/src/components/drawer/Routing.tsx
+++ b/client/src/components/drawer/Routing.tsx
@@ -48,7 +48,7 @@ export default function RoutingTab() {
       <Collapse in={mode !== 'bootstrap'}>
         <MultiOptionList
           field="category"
-          buttons={['pokestop', 'gym', 'spawnpoint']}
+          buttons={['pokestop', 'gym', 'fort', 'spawnpoint']}
           disabled={mode === 'bootstrap'}
           type="select"
         />

--- a/client/src/hooks/usePersist.ts
+++ b/client/src/hooks/usePersist.ts
@@ -44,7 +44,7 @@ export interface UsePersist {
   s2FillMode: 'all' | 'simple'
 
   // Clustering
-  category: Category
+  category: Category | 'fort'
   tth: 'All' | 'Known' | 'Unknown'
   lineColorRules: { distance: number; color: string }[]
   mode: 'bootstrap' | 'route' | 'cluster'

--- a/client/src/pages/map/markers/index.tsx
+++ b/client/src/pages/map/markers/index.tsx
@@ -4,19 +4,15 @@ import geohash from 'ngeohash'
 import { shallow } from 'zustand/shallow'
 
 import { ICON_RADIUS, ICON_COLOR } from '@assets/constants'
-import { UsePersist, usePersist } from '@hooks/usePersist'
+import { usePersist } from '@hooks/usePersist'
 import usePixi from '@hooks/usePixi'
 import { useStatic } from '@hooks/useStatic'
 import useDeepCompareEffect from 'use-deep-compare-effect'
 import { getMarkers } from '@services/fetches'
-import { PixiMarker } from '@assets/types'
+import { Category, PixiMarker } from '@assets/types'
 import StyledPopup from '../popups/Styled'
 
-export default function Markers({
-  category,
-}: {
-  category: UsePersist['category']
-}) {
+export default function Markers({ category }: { category: Category }) {
   const enabled = usePersist((s) => s[category], shallow)
   const nativeLeaflet = usePersist((s) => s.nativeLeaflet)
   const data = usePersist((s) => s.data)

--- a/client/src/services/fetches.ts
+++ b/client/src/services/fetches.ts
@@ -111,7 +111,7 @@ export async function clusteringRouting(): Promise<FeatureCollection> {
   const {
     mode,
     radius,
-    category,
+    category: rawCategory,
     min_points,
     fast,
     route_split_level,
@@ -134,6 +134,7 @@ export async function clusteringRouting(): Promise<FeatureCollection> {
     x.geometry.type.includes('Polygon'),
   )
   const last_seen = typeof raw === 'string' ? new Date(raw) : raw
+  const category = rawCategory === 'fort' ? 'gym' : rawCategory
 
   if (!areas.length) {
     areas.push({
@@ -186,7 +187,7 @@ export async function clusteringRouting(): Promise<FeatureCollection> {
       const res = await fetch(
         mode === 'bootstrap'
           ? '/api/v1/calc/bootstrap'
-          : `/api/v1/calc/${mode}/${category}`,
+          : `/api/v1/calc/${mode}/${rawCategory}`,
         {
           keepalive: true,
           method: 'POST',

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koji-docs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Documentation for Kōji",
   "scripts": {
     "dev": "next dev",

--- a/docs/pages/api-reference/endpoints.mdx
+++ b/docs/pages/api-reference/endpoints.mdx
@@ -52,11 +52,13 @@
 - **Returns**:
   - Bootstrap route data for the specified area/instance with the specified radius
 
-### `/api/v1/calc/cluster`
+### `/api/v1/calc/cluster/{category}`
 
-### `/api/v1/calc/route`
+### `/api/v1/calc/route/{category}`
 
 - **Method:** `POST`
+- **URL Params**:
+  - Category: `pokestop`, `gym`, `spawnpoint, or `fort`
 - **JSON Body**:
   - **Required**:
     - `area` OR `instance` OR `data_points`

--- a/docs/pages/client/map.mdx
+++ b/docs/pages/client/map.mdx
@@ -28,6 +28,7 @@ import { Callout } from 'nextra-theme-docs'
   - `Route` - clusters and routes the points using OR-Tools
 - Category
   - Select the category/table for the clustering algorithm to read from the database
+  - `Fort` will include both Pokestops and Gyms
 - Strategy
   - `Radius` - clusters based on the selected radius
   - `S2` - clusters based on the selected S2 cell level and size

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -28,8 +28,7 @@ const config: DocsThemeConfig = {
   feedback: {
     content: null,
   },
-  docsRepositoryBase:
-    'https://github.com/TurtIeSocks/Koji/tree/main/docs/pages',
+  docsRepositoryBase: 'https://github.com/TurtIeSocks/Koji/tree/main/docs',
   footer: {
     text: (
       <div

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -28,7 +28,7 @@ const config: DocsThemeConfig = {
   feedback: {
     content: null,
   },
-  docsRepositoryBase: 'https://github.com/TurtIeSocks/Koji/tree/main/docs',
+  docsRepositoryBase: 'https://github.com/TurtIeSocks/Koji/edit/main/docs',
   footer: {
     text: (
       <div

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -358,7 +358,7 @@ checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "api"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "actix-files",
  "actix-session",
@@ -2029,7 +2029,7 @@ dependencies = [
 
 [[package]]
 name = "model"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "futures",

--- a/server/api/Cargo.toml
+++ b/server/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 publish = false
 

--- a/server/api/src/public/v1/calculate.rs
+++ b/server/api/src/public/v1/calculate.rs
@@ -155,7 +155,7 @@ async fn cluster(
     }
 
     let mut stats = Stats::new();
-    let enum_type = if category == "gym" {
+    let enum_type = if category == "gym" || category == "fort" {
         if scanner_type == "rdm" {
             Type::CircleSmartRaid
         } else {

--- a/server/api/src/utils/mod.rs
+++ b/server/api/src/utils/mod.rs
@@ -102,6 +102,11 @@ pub async fn points_from_area(
             "gym" => gym::Query::area(&conn.data_db, &area, last_seen).await,
             "pokestop" => pokestop::Query::area(&conn.data_db, &area, last_seen).await,
             "spawnpoint" => spawnpoint::Query::area(&conn.data_db, &area, last_seen, tth).await,
+            "fort" => {
+                let gyms = gym::Query::area(&conn.data_db, &area, last_seen).await?;
+                let pokestops = pokestop::Query::area(&conn.data_db, &area, last_seen).await?;
+                Ok(gyms.into_iter().chain(pokestops.into_iter()).collect())
+            }
             _ => Err(DbErr::Custom("Invalid Category".to_string())),
         }
     } else {

--- a/server/model/Cargo.toml
+++ b/server/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "model"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 publish = false
 

--- a/server/model/src/utils/mod.rs
+++ b/server/model/src/utils/mod.rs
@@ -135,7 +135,8 @@ pub async fn get_database_struct() -> KojiDb {
         100
     };
 
-    let unown_db_url = env::var("UNOWN_DB").unwrap_or("".to_string());
+    let unown_db_url =
+        env::var("UNOWN_DB_URL").unwrap_or(env::var("UNOWN_DB").unwrap_or("".to_string()));
 
     KojiDb {
         data_db: {


### PR DESCRIPTION
- Adds fort category to backend and client
- `fort` enables clustering/routing for pokestops and gyms at the same time
- Also fixes unown_db_url since this will be merged before #128