### PR TITLE
add parent column

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "koji",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Tool to make RDM routes",
   "main": "server/dist/index.js",
   "author": "TurtIeSocks <58572875+TurtIeSocks@users.noreply.github.com>",

--- a/client/src/assets/types.ts
+++ b/client/src/assets/types.ts
@@ -110,6 +110,7 @@ export type BasicKojiEntry = {
 
 export interface KojiGeofence extends BasicKojiEntry {
   mode: KojiModes
+  parent?: number
   geometry: Polygon | MultiPolygon
   geo_type: 'Polygon' | 'MultiPolygon'
 }
@@ -146,6 +147,7 @@ export interface KojiTileServer extends BasicKojiEntry {
 export interface AdminGeofence extends KojiGeofence {
   properties: KojiGeoProperty[]
   projects: number[]
+  routes: number[]
 }
 
 export interface AdminProject extends KojiProject {

--- a/client/src/pages/admin/geofence/GeofenceExpand.tsx
+++ b/client/src/pages/admin/geofence/GeofenceExpand.tsx
@@ -8,6 +8,22 @@ export function GeofenceExpand() {
   const record = useRecordContext<AdminGeofence>()
   return (
     <Grid2 container justifyContent="flex-start">
+      <Grid2 xs={4}>
+        <ListItemText
+          primary="Projects"
+          secondary={record.projects?.length || 0}
+        />
+      </Grid2>
+      <Grid2 xs={4}>
+        <ListItemText
+          primary="Properties"
+          secondary={record.properties?.length || 0}
+        />
+      </Grid2>
+      <Grid2 xs={4}>
+        <ListItemText primary="Routes" secondary={record.routes?.length || 0} />
+      </Grid2>
+
       {(record.properties || []).map((p) => (
         <Grid2 key={p.name} xs={6} sm={4} md={3} lg={2}>
           <ListItemText primary={p.name} secondary={`${p.value}`} />

--- a/client/src/pages/admin/geofence/GeofenceForm.tsx
+++ b/client/src/pages/admin/geofence/GeofenceForm.tsx
@@ -65,6 +65,7 @@ export default function GeofenceForm() {
         optionText="mode"
         optionValue="mode"
       />
+      <ReferenceInput source="parent" reference="geofence" />
       <ArrayInput source="properties" sx={{ my: 2 }}>
         <SimpleFormIterator inline>
           <ReferenceInput

--- a/client/src/pages/admin/geofence/GeofenceList.tsx
+++ b/client/src/pages/admin/geofence/GeofenceList.tsx
@@ -5,12 +5,12 @@ import {
   DeleteWithUndoButton,
   EditButton,
   List,
-  NumberField,
   Pagination,
   TextField,
   TopToolbar,
   CreateButton,
   SearchInput,
+  ReferenceField,
 } from 'react-admin'
 
 import { ExportPolygon } from '@components/dialogs/Polygon'
@@ -56,19 +56,9 @@ export default function GeofenceList() {
           expand={GeofenceExpand}
         >
           <TextField source="name" />
+          <ReferenceField source="parent" reference="geofence" />
           <TextField source="mode" />
           <TextField source="geo_type" />
-          <NumberField
-            source="projects.length"
-            label="Projects"
-            sortable={false}
-          />
-          <NumberField
-            source="properties.length"
-            label="Properties"
-            sortable={false}
-          />
-          <NumberField source="routes.length" label="Routes" sortable={false} />
           <EditButton />
           <DeleteWithUndoButton />
           <PushToProd resource="geofence" />

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "koji"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "dotenv",
@@ -1975,7 +1975,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "migration"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-std",
  "geojson",
@@ -2029,7 +2029,7 @@ dependencies = [
 
 [[package]]
 name = "model"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "chrono",
  "futures",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koji"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 
 [workspace]

--- a/server/migration/Cargo.toml
+++ b/server/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "migration"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 publish = false
 

--- a/server/migration/src/lib.rs
+++ b/server/migration/src/lib.rs
@@ -17,6 +17,7 @@ mod m20230205_121524_fix_timestamps;
 mod m20230221_130117_geofence_mode_enums;
 mod m20230221_143509_route_mode_enums;
 mod m20230301_051446_tile_server_table;
+mod m20230407_045757_parent_column;
 
 pub struct Migrator;
 
@@ -41,6 +42,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230221_130117_geofence_mode_enums::Migration),
             Box::new(m20230221_143509_route_mode_enums::Migration),
             Box::new(m20230301_051446_tile_server_table::Migration),
+            Box::new(m20230407_045757_parent_column::Migration),
         ]
     }
 }

--- a/server/migration/src/m20221207_120629_create_geofence.rs
+++ b/server/migration/src/m20221207_120629_create_geofence.rs
@@ -46,6 +46,7 @@ pub enum Geofence {
     Table,
     Id,
     Name,
+    Parent,
     Mode,
     Area,
     Geometry,

--- a/server/migration/src/m20230407_045757_parent_column.rs
+++ b/server/migration/src/m20230407_045757_parent_column.rs
@@ -1,0 +1,43 @@
+use sea_orm_migration::prelude::*;
+
+use crate::m20221207_120629_create_geofence::Geofence;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Geofence::Table)
+                    .add_column(ColumnDef::new(Geofence::Parent).unsigned())
+                    .drop_column(Geofence::Area)
+                    .add_foreign_key(
+                        &TableForeignKey::new()
+                            .name("FK_parent_id")
+                            .from_tbl(Geofence::Table)
+                            .from_col(Geofence::Parent)
+                            .to_tbl(Geofence::Table)
+                            .to_col(Geofence::Id)
+                            .to_owned(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Geofence::Table)
+                    .drop_column(Geofence::Parent)
+                    .add_column(ColumnDef::new(Geofence::Area).json())
+                    .drop_foreign_key(Alias::new("FK_parent_id"))
+                    .to_owned(),
+            )
+            .await
+    }
+}

--- a/server/model/Cargo.toml
+++ b/server/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "model"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 publish = false
 

--- a/server/model/src/db/geofence_property.rs
+++ b/server/model/src/db/geofence_property.rs
@@ -64,7 +64,7 @@ pub struct FullPropertyModel {
 }
 
 impl FullPropertyModel {
-    pub fn parse_db_value(self, model: &geofence::Model) -> serde_json::Value {
+    pub fn parse_db_value(&self, model: &geofence::Model) -> serde_json::Value {
         let model_json = serde_json::to_value(model).unwrap();
 
         let parsed_value = match self.category {

--- a/server/model/src/utils/json.rs
+++ b/server/model/src/utils/json.rs
@@ -45,10 +45,20 @@ impl JsonToModel for Value {
                             } else {
                                 None
                             };
+                            let parent = if let Some(parent) = incoming.get("parent") {
+                                if let Some(parent) = parent.as_u64() {
+                                    Some(parent as u32)
+                                } else {
+                                    None
+                                }
+                            } else {
+                                None
+                            };
                             let mode = get_enum(mode);
                             Ok(geofence::ActiveModel {
                                 name: Set(name.to_string()),
                                 geometry: Set(value),
+                                parent: Set(parent),
                                 mode: Set(mode),
                                 ..Default::default()
                             })


### PR DESCRIPTION
- adds a self referencing parent column to the geofence table
- related ui components to the admin panel
- respects database and custom name columns of the parent to be selected at feature building
- also drops the legacy area column

Resolves #134 