### PR TITLE
Rework point drawing

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "koji",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Tool to make RDM routes",
   "main": "server/dist/index.js",
   "author": "TurtIeSocks <58572875+TurtIeSocks@users.noreply.github.com>",

--- a/client/src/assets/types.ts
+++ b/client/src/assets/types.ts
@@ -61,6 +61,7 @@ export type Properties<G extends Geometry | null = Geometry> =
     __mode?: KojiModes
     __projects?: number[]
     __cells?: string[]
+    __index?: number
   }
 
 export interface Feature<G extends Geometry | null = Geometry, P = Properties>

--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -59,7 +59,7 @@ export default class ErrorBoundary extends Component<
       <>
         <Notification
           CollapseProps={{ in: this.state.hasError }}
-          title="Kōji encountered an error!"
+          title="Kōji encountered an error and has attempted to recover"
           IconButtonProps={{
             onClick: () => this.setState({ hasError: false }),
           }}

--- a/client/src/components/dialogs/ImportExport.tsx
+++ b/client/src/components/dialogs/ImportExport.tsx
@@ -69,6 +69,7 @@ export function ImportExportDialog({
               code={code}
               setCode={setCode}
               maxHeight="70vh"
+              width="100%"
               textMode={
                 mode === 'Export'
                   ? polygonExportMode === 'text' ||
@@ -81,35 +82,43 @@ export function ImportExportDialog({
         </Grid2>
       </DialogContent>
       <DialogActions>
-        {mode === 'Export' && (
-          <>
-            <MultiOptions
-              field="polygonExportMode"
-              buttons={CONVERSION_TYPES}
-              type="select"
-            />
-            <SplitMultiPolygonsBtn
-              fc={
-                feature.type === 'FeatureCollection'
-                  ? feature
-                  : { type: 'FeatureCollection', features: [feature] }
-              }
-              setter={setCode}
-            />
-          </>
-        )}
-        <ClipboardButton text={code} />
-        <Button
-          disabled={!!error}
-          onClick={() => {
-            if (mode === 'Import' && feature.type === 'FeatureCollection') {
-              add(feature.features)
-            }
-            reset()
-          }}
+        <div style={{ flexGrow: 0 }}>
+          {mode === 'Export' && (
+            <>
+              <MultiOptions
+                field="polygonExportMode"
+                buttons={CONVERSION_TYPES}
+                type="select"
+              />
+              {shape === 'Polygon' && (
+                <SplitMultiPolygonsBtn
+                  fc={
+                    feature.type === 'FeatureCollection'
+                      ? feature
+                      : { type: 'FeatureCollection', features: [feature] }
+                  }
+                  setter={setCode}
+                />
+              )}
+            </>
+          )}
+        </div>
+        <div
+          style={{ flexGrow: 1, display: 'flex', justifyContent: 'flex-end' }}
         >
-          {mode === 'Import' ? 'Import' : 'Close'}
-        </Button>
+          <ClipboardButton text={code} />
+          <Button
+            disabled={!!error}
+            onClick={() => {
+              if (mode === 'Import' && feature.type === 'FeatureCollection') {
+                add(feature.features)
+              }
+              reset()
+            }}
+          >
+            {mode === 'Import' ? 'Import' : 'Close'}
+          </Button>
+        </div>
       </DialogActions>
     </Dialog>
   )

--- a/client/src/components/drawer/inputs/Clipboard.tsx
+++ b/client/src/components/drawer/inputs/Clipboard.tsx
@@ -1,10 +1,18 @@
 import * as React from 'react'
 import Button from '@mui/material/Button'
+import { Tooltip } from '@mui/material'
+
+const https = !!navigator.clipboard
 
 export default function ClipboardButton({ text }: { text: string }) {
   return (
-    <Button onPointerDown={() => navigator.clipboard.writeText(text)}>
-      Copy to Clipboard
-    </Button>
+    <Tooltip title={https ? '' : 'This requires a secure connection to use'}>
+      <Button
+        disabled={!https}
+        onPointerDown={() => navigator.clipboard.writeText(text)}
+      >
+        Copy to Clipboard
+      </Button>
+    </Tooltip>
   )
 }

--- a/client/src/hooks/useSyncGeojson.ts
+++ b/client/src/hooks/useSyncGeojson.ts
@@ -6,7 +6,14 @@ import { UseShapes, useShapes } from '@hooks/useShapes'
 import { s2Coverage } from '@services/fetches'
 
 import { useStatic } from './useStatic'
-import { useDbCache } from './useDbCache'
+import { UseDbCache, useDbCache } from './useDbCache'
+
+declare global {
+  interface Window {
+    shapes: UseShapes
+    cache: UseDbCache
+  }
+}
 
 export default function useSyncGeojson() {
   const points = useShapes((s) => s.Point)
@@ -15,14 +22,15 @@ export default function useSyncGeojson() {
   const multiLineStrings = useShapes((s) => s.MultiLineString)
   const polygons = useShapes((s) => s.Polygon)
   const multiPolygons = useShapes((s) => s.MultiPolygon)
-
   const geojson = useStatic((s) => s.geojson)
 
   const setStatic = useStatic((s) => s.setStatic)
 
   if (process.env.NODE_ENV === 'development') {
-    console.log('Shape Debug:', useShapes.getState())
-    console.log('Cache Debug:', useDbCache.getState())
+    window.shapes = useShapes.getState()
+    window.cache = useDbCache.getState()
+    // console.log('Shape Debug:', useShapes.getState())
+    // console.log('Cache Debug:', useDbCache.getState())
   }
   useDeepCompareEffect(() => {
     const newGeojson: FeatureCollection = {

--- a/client/src/pages/map/index.tsx
+++ b/client/src/pages/map/index.tsx
@@ -44,49 +44,49 @@ export default function MapWrapper() {
       <Loading />
       <ErrorBoundary>
         <DrawerIndex drawerWidth={drawerWidth} />
+        <Main open={drawer} drawerWidth={drawerWidth}>
+          <Map
+            forcedLocation={
+              params.lat && params.lon ? [+params.lat, +params.lon] : undefined
+            }
+            forcedZoom={params.zoom ? +params.zoom : undefined}
+            style={{
+              position: 'absolute',
+              maxWidth: '100% !important',
+              maxHeight: '100% !important',
+              margin: 'auto',
+              top: 0,
+              bottom: 0,
+              left: 0,
+              right: 0,
+            }}
+          >
+            <Pane name="circles" style={{ zIndex: 504 }} />
+            <Pane name="lines" style={{ zIndex: 503 }} />
+            <Pane name="arrows" style={{ zIndex: 502 }} />
+            <Pane name="polygons" style={{ zIndex: 501 }} />
+            <Pane name="s2" style={{ zIndex: 500 }} />
+            <Markers category="pokestop" />
+            <Markers category="spawnpoint" />
+            <Markers category="gym" />
+            <Interface />
+            <Points />
+            <MultiPoints />
+            <LineStrings />
+            <MultiLineStrings />
+            <Polygons />
+            <S2Cells />
+            <SimplifiedPolygons />
+          </Map>
+          <NetworkAlert />
+          <GeneralAlert />
+          <ImportPolygon />
+          <ExportPolygon />
+          <ImportRoute />
+          <ExportRoute />
+          <KeyboardShortcuts />
+        </Main>
       </ErrorBoundary>
-      <Main open={drawer} drawerWidth={drawerWidth}>
-        <Map
-          forcedLocation={
-            params.lat && params.lon ? [+params.lat, +params.lon] : undefined
-          }
-          forcedZoom={params.zoom ? +params.zoom : undefined}
-          style={{
-            position: 'absolute',
-            maxWidth: '100% !important',
-            maxHeight: '100% !important',
-            margin: 'auto',
-            top: 0,
-            bottom: 0,
-            left: 0,
-            right: 0,
-          }}
-        >
-          <Pane name="circles" style={{ zIndex: 504 }} />
-          <Pane name="lines" style={{ zIndex: 503 }} />
-          <Pane name="arrows" style={{ zIndex: 502 }} />
-          <Pane name="polygons" style={{ zIndex: 501 }} />
-          <Pane name="s2" style={{ zIndex: 500 }} />
-          <Markers category="pokestop" />
-          <Markers category="spawnpoint" />
-          <Markers category="gym" />
-          <Interface />
-          <Points />
-          <MultiPoints />
-          <LineStrings />
-          <MultiLineStrings />
-          <Polygons />
-          <S2Cells />
-          <SimplifiedPolygons />
-        </Map>
-        <NetworkAlert />
-        <GeneralAlert />
-        <ImportPolygon />
-        <ExportPolygon />
-        <ImportRoute />
-        <ExportRoute />
-        <KeyboardShortcuts />
-      </Main>
     </Box>
   )
 }

--- a/client/src/pages/map/markers/MultiPoint.tsx
+++ b/client/src/pages/map/markers/MultiPoint.tsx
@@ -14,8 +14,10 @@ export function KojiMultiPoint({
   },
   radius,
   dbRef,
+  combined,
 }: {
   feature: Feature<MultiPoint>
+  combined?: boolean
   radius: number
   dbRef: DbOption | null
 }) {
@@ -43,6 +45,7 @@ export function KojiMultiPoint({
               index={i}
               type="MultiPoint"
               dbRef={dbRef}
+              combined={combined}
             />
             <MemoLineString
               key={`${first}-${isEnd}-${coordinates.length}`}
@@ -60,4 +63,8 @@ export function KojiMultiPoint({
   )
 }
 
-export const MemoMultiPoint = React.memo(KojiMultiPoint)
+export const MemoMultiPoint = React.memo(
+  KojiMultiPoint,
+  (prev, next) =>
+    prev.combined === next.combined && prev.radius === next.radius,
+)

--- a/client/src/pages/map/markers/Vectors.tsx
+++ b/client/src/pages/map/markers/Vectors.tsx
@@ -13,6 +13,8 @@ import { MemoMultiLineString } from './MultiLineString'
 
 export function Points() {
   const shapes = useShapes((s) => s.Point)
+  const combined = useShapes((s) => s.combined)
+
   const radius = usePersist((s) => s.radius)
   const setActiveMode = usePersist((s) => s.setActiveMode)
   const showRouteIndex = usePersist((s) => s.showRouteIndex)
@@ -28,6 +30,7 @@ export function Points() {
           radius={calculation_mode === 'Radius' ? radius || 10 : 100}
           index={showRouteIndex ? i + 1 : NaN}
           dbRef={getFromKojiKey(feature.properties.__multipoint_id)}
+          combined={combined[id]}
         />
       ))}
     </React.Fragment>
@@ -36,6 +39,8 @@ export function Points() {
 
 export function MultiPoints() {
   const shapes = useShapes((s) => s.MultiPoint)
+  const combined = useShapes((s) => s.combined)
+
   const radius = usePersist((s) => s.radius)
   const setActiveMode = usePersist((s) => s.setActiveMode)
   const calculation_mode = usePersist((s) => s.calculation_mode)
@@ -49,6 +54,7 @@ export function MultiPoints() {
           feature={feature}
           radius={calculation_mode === 'Radius' ? radius || 10 : 100}
           dbRef={getFromKojiKey(id)}
+          combined={combined[id]}
         />
       ))}
     </React.Fragment>

--- a/client/src/pages/map/popups/Point.tsx
+++ b/client/src/pages/map/popups/Point.tsx
@@ -183,7 +183,8 @@ export function PointPopup({ id, lat, lon, type: geoType, dbRef }: Props) {
           disabled={loading}
           onClick={async () => {
             setLoading(true)
-            const { fast, route_split_level } = usePersist.getState()
+            const { fast, route_split_level, save_to_db } =
+              usePersist.getState()
             const { setStatic } = useStatic.getState()
             setStatic('loading', { [name]: null })
             setStatic('totalLoadingTime', 0)
@@ -205,13 +206,15 @@ export function PointPopup({ id, lat, lon, type: geoType, dbRef }: Props) {
               }),
             }).then((res) => {
               if (res) {
-                useStatic.setState({
-                  notification: {
-                    message: 'Saved successfully!',
-                    status: 200,
-                    severity: 'success',
-                  },
-                })
+                if (save_to_db) {
+                  useStatic.setState({
+                    notification: {
+                      message: 'Saved successfully!',
+                      status: 200,
+                      severity: 'success',
+                    },
+                  })
+                }
                 const end = Date.now() - start
                 if (res.stats) {
                   setStatic('loading', (prev) => ({

--- a/client/src/pages/map/popups/Polygon.tsx
+++ b/client/src/pages/map/popups/Polygon.tsx
@@ -241,6 +241,9 @@ export function PolygonPopup({
         <MenuItem dense onClick={() => filterPoints(feature)}>
           Remove Non-Contained Points
         </MenuItem>
+        <MenuItem dense onClick={() => filterPoints(feature, true, true)}>
+          Combine Contained Points
+        </MenuItem>
         {...feature.geometry.type === 'MultiPolygon'
           ? [
               <MenuItem

--- a/client/src/services/fetches.ts
+++ b/client/src/services/fetches.ts
@@ -130,8 +130,11 @@ export async function clusteringRouting(): Promise<FeatureCollection> {
   const { add, activeRoute } = useShapes.getState().setters
   const { getFromKojiKey, getRouteByCategory } = useDbCache.getState()
 
-  const areas = (geojson?.features || []).filter((x) =>
-    x.geometry.type.includes('Polygon'),
+  const areas = (geojson?.features || []).filter(
+    (x) =>
+      x.geometry.type.includes('Polygon') &&
+      x.geometry.type !== 'GeometryCollection' &&
+      x.geometry.coordinates.length,
   )
   const last_seen = typeof raw === 'string' ? new Date(raw) : raw
   const category = rawCategory === 'fort' ? 'gym' : rawCategory
@@ -159,7 +162,7 @@ export async function clusteringRouting(): Promise<FeatureCollection> {
     })
   }
 
-  activeRoute('layer_1')
+  activeRoute('0__unset__CLIENT')
   useStatic.setState({
     loading: Object.fromEntries(
       areas.map((k) => [

--- a/client/src/services/geoUtils.ts
+++ b/client/src/services/geoUtils.ts
@@ -3,43 +3,90 @@ import pointInPolygon from '@turf/boolean-point-in-polygon'
 
 import { useShapes } from '@hooks/useShapes'
 import type { Feature } from '@assets/types'
-import type { Point, MultiPolygon, Polygon } from 'geojson'
+import type {
+  Point,
+  MultiPolygon,
+  Polygon,
+  MultiPoint,
+  Position,
+} from 'geojson'
 
 export function filterPoints(
   feature: Feature<Polygon | MultiPolygon>,
   contains = false,
+  merge = false,
 ) {
   const {
     Point,
     MultiPoint,
-    setters: { remove, add },
+    newRouteCount,
+    setters: { remove, add, activeRoute },
   } = useShapes.getState()
+  const merged: Feature<MultiPoint> = {
+    type: 'Feature',
+    id: `newRoute${newRouteCount + 1}`,
+    geometry: {
+      type: 'MultiPoint',
+      coordinates: [],
+    },
+    properties: {},
+  }
+
   Object.entries(Point).forEach(([key, value]) => {
     const inside = pointInPolygon(value, feature.geometry)
-    if (contains ? inside : !inside) remove(value.geometry.type, key)
+    if (contains ? inside : !inside) {
+      remove(value.geometry.type, key)
+      if (merge) {
+        merged.geometry.coordinates.push(value.geometry.coordinates)
+      }
+    }
   })
   Object.entries(MultiPoint).forEach(([key, value]) => {
     const points: Point[] = value.geometry.coordinates.map((c) => ({
       type: 'Point',
       coordinates: c,
     }))
+    const others: Position[] = []
     const filtered = points.filter((p) => {
       const inside = pointInPolygon(p, feature.geometry)
+      if (merge) {
+        if (contains ? !inside : inside) {
+          others.push(p.coordinates)
+        }
+      }
       return contains ? inside : !inside
     })
     if (filtered.length) {
       remove(value.geometry.type, key)
+      if (merge) {
+        merged.geometry.coordinates.push(...filtered.map((p) => p.coordinates))
+      }
       if (filtered.length !== points.length) {
-        add({
-          ...value,
-          geometry: {
-            type: 'MultiPoint',
-            coordinates: filtered.map((p) => p.coordinates),
-          },
-        })
+        if (merge) {
+          add({
+            ...value,
+            geometry: {
+              type: 'MultiPoint',
+              coordinates: others,
+            },
+          })
+        } else {
+          add({
+            ...value,
+            geometry: {
+              type: 'MultiPoint',
+              coordinates: filtered.map((p) => p.coordinates),
+            },
+          })
+        }
       }
     }
   })
+  if (merged.geometry.coordinates.length) {
+    useShapes.setState({ newRouteCount: newRouteCount + 1 })
+    add(merged)
+    activeRoute()
+  }
 }
 
 export function filterPolys(

--- a/client/src/services/utils.ts
+++ b/client/src/services/utils.ts
@@ -13,6 +13,7 @@ import {
   KojiRouteModes,
 } from '@assets/types'
 import { usePersist } from '@hooks/usePersist'
+import { VECTOR_COLORS } from '@assets/constants'
 
 export function getMapBounds(map: L.Map) {
   const mapBounds = map.getBounds()
@@ -261,4 +262,22 @@ export function getRouteType(category: Category): KojiRouteModes {
     default:
       return scannerType === 'rdm' ? 'circle_smart_pokemon' : 'circle_pokemon'
   }
+}
+
+export function getPolygonColor(id: string) {
+  return id.includes('__SCANNER') ? VECTOR_COLORS.GREEN : VECTOR_COLORS.BLUE
+}
+
+export function getPointColor(
+  id: string,
+  type: 'Point' | 'MultiPoint',
+  index: number,
+) {
+  return type === 'Point'
+    ? VECTOR_COLORS.RED
+    : index === 0
+    ? VECTOR_COLORS.PURPLE
+    : id.includes('__SCANNER')
+    ? VECTOR_COLORS.GREEN
+    : VECTOR_COLORS.BLUE
 }

--- a/docs/pages/client/map.mdx
+++ b/docs/pages/client/map.mdx
@@ -185,7 +185,9 @@ From top to bottom:
 - 🚧 Enables cut mode, which allows you to cut shapes out of existing polygons 🚧
 - Removes shapes, either individually or all for a specified type
 - Rotates shapes
-- Merges selected polygons into one
+
+- Merges selected geofences or routes into one
+
 - Navigates to the admin panel
 - Zoom Controls
 - Set location


### PR DESCRIPTION
Primary:
- rework how drawing points works a bit
- now if you start drawing circles while a route is active, those points extend that route
- cancel "undos" added points, but maintains the original route if there is one
- make `__multipoint_id` more consistent ID wise
- allow merging of routes via the merge button that was previously only for polygons
- move some color determinations to functions for consistency
- force rerender based on combined status
- move common leaflet events to the eventhandlers prop instead of in the ref
- adds the ability to merge all points within a given polygon, action is in the polygon popup => map menu

Resolves #137
Resolves #139

Others:
- Hide split multi polygons when exporting routes
- Push others buttons to the left
- Disable clipboard if fn is unavailable (unsecure)
- Extend error boundary to map for better catching
- Move shape and cache debug logs to window object in dev mode
- remove "saved successfully from rerouting if `save_to_db` is not enabled
- filter out empty polygons/multipolygons when clustering