### PR TITLE
import wizard & rdm sync fixes

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "koji",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Tool to make RDM routes",
   "main": "server/dist/index.js",
   "author": "TurtIeSocks <58572875+TurtIeSocks@users.noreply.github.com>",

--- a/client/src/components/buttons/SaveToKoji.tsx
+++ b/client/src/components/buttons/SaveToKoji.tsx
@@ -10,7 +10,7 @@ interface Props extends ButtonProps {
 
 export default function SaveToKoji({ fc, ...rest }: Props) {
   const [loading, setLoading] = React.useState(false)
-  const routes = {
+  const routes: FeatureCollection = {
     type: 'FeatureCollection',
     features: fc.features.filter((feat) => feat.geometry.type === 'MultiPoint'),
   }
@@ -35,10 +35,13 @@ export default function SaveToKoji({ fc, ...rest }: Props) {
                   ...feat,
                   properties: {
                     ...feat.properties,
-                    __geofence_id: Object.values(newFences || {}).find(
-                      (x) =>
-                        x.name === feat.properties.__geofence_id?.toString(),
-                    )?.id,
+                    __geofence_id:
+                      Object.values(newFences || {}).find(
+                        (x) =>
+                          x.name === feat.properties.__geofence_id?.toString(),
+                      )?.id ||
+                      feat.properties.__geofence_id ||
+                      feat.properties.geofence_id,
                   },
                 })),
               ),

--- a/client/src/components/dialogs/import/AssignStep.tsx
+++ b/client/src/components/dialogs/import/AssignStep.tsx
@@ -72,8 +72,16 @@ const AssignStep = React.forwardRef<
     }))
   }, [])
 
-  const all = Object.values(checked).every((val) => val)
-  const some = !all && Object.values(checked).some((val) => val)
+  const all = Object.entries(checked)
+    .filter(([k]) => (routeMode ? k.includes('circle') : !k.includes('circle')))
+    .every(([, val]) => val)
+  const some =
+    !all &&
+    Object.entries(checked)
+      .filter(([k]) =>
+        routeMode ? k.includes('circle') : !k.includes('circle'),
+      )
+      .some(([, val]) => val)
 
   const sorted = React.useMemo(
     () =>
@@ -118,7 +126,12 @@ const AssignStep = React.forwardRef<
               importWizard: {
                 ...prev.importWizard,
                 checked: Object.fromEntries(
-                  Object.keys(checked).map((k) => [k, !all && !some]),
+                  Object.entries(checked).map(([k, v]) => [
+                    k,
+                    (routeMode ? k.includes('circle') : !k.includes('circle'))
+                      ? !all && !some
+                      : v,
+                  ]),
                 ),
               },
             }))

--- a/client/src/components/dialogs/import/Finish.tsx
+++ b/client/src/components/dialogs/import/Finish.tsx
@@ -22,9 +22,12 @@ export default function FinishStep({ filtered, reset }: Props) {
         __mode: feat.properties?.mode,
         __projects: feat.properties?.projects,
         __geofence_id: feat.properties?.geofence_id,
+        __parent: feat.properties?.parent,
         name: undefined,
         mode: undefined,
         projects: undefined,
+        geofence_id: undefined,
+        parent: undefined,
       },
     })),
   }

--- a/client/src/components/drawer/Routing.tsx
+++ b/client/src/components/drawer/Routing.tsx
@@ -123,14 +123,20 @@ export default function RoutingTab() {
       <Toggle
         field="save_to_db"
         label="Save to Kōji Db"
-        disabled={scannerType === 'rdm' && category === 'pokestop'}
+        disabled={
+          scannerType === 'rdm' &&
+          category === 'pokestop' &&
+          mode !== 'bootstrap'
+        }
       />
       <Toggle
         field="save_to_scanner"
         label="Save to Scanner Db"
         disabled={
           !useStatic.getState().dangerous ||
-          (scannerType === 'rdm' && category === 'pokestop')
+          (scannerType === 'rdm' &&
+            category === 'pokestop' &&
+            mode !== 'bootstrap')
         }
       />
       <Toggle field="skipRendering" />

--- a/client/src/pages/admin/index.tsx
+++ b/client/src/pages/admin/index.tsx
@@ -7,6 +7,7 @@ import Route from '@mui/icons-material/Route'
 import ListAlt from '@mui/icons-material/ListAlt'
 import Map from '@mui/icons-material/Map'
 
+import NetworkAlert from '@components/notifications/NetworkStatus'
 import { getFullCache } from '@services/fetches'
 
 import { dataProvider } from './dataProvider'
@@ -45,62 +46,65 @@ export default function AdminPanel() {
   }, [])
 
   return (
-    <Admin
-      basename="/admin"
-      title="Kōji Admin"
-      dataProvider={dataProvider}
-      disableTelemetry
-      theme={{
-        ...defaultTheme,
-        ...(theme as RaThemeOptions),
-      }}
-      layout={Layout}
-    >
-      <Resource
-        name="project"
-        icon={AccountTree}
-        list={ProjectList}
-        edit={ProjectEdit}
-        show={ProjectShow}
-        create={ProjectCreate}
-        recordRepresentation={(record) => record.name || ''}
-      />
-      <Resource
-        name="geofence"
-        icon={Architecture}
-        list={GeofenceList}
-        edit={GeofenceEdit}
-        show={GeofenceShow}
-        create={GeofenceCreate}
-        recordRepresentation={(record) => record.name || ''}
-      />
-      <Resource
-        name="route"
-        icon={Route}
-        list={RouteList}
-        edit={RouteEdit}
-        show={RouteShow}
-        create={RouteCreate}
-        recordRepresentation={(record) => record.name || ''}
-      />
-      <Resource
-        name="property"
-        icon={ListAlt}
-        list={PropertyList}
-        edit={PropertyEdit}
-        show={PropertyShow}
-        create={PropertyCreate}
-        recordRepresentation={(record) => record.name || ''}
-      />
-      <Resource
-        name="tileserver"
-        icon={Map}
-        list={TileServerList}
-        edit={TileServerEdit}
-        show={TileServerShow}
-        create={TileServerCreate}
-        recordRepresentation={(record) => record.name || ''}
-      />
-    </Admin>
+    <>
+      <Admin
+        basename="/admin"
+        title="Kōji Admin"
+        dataProvider={dataProvider}
+        disableTelemetry
+        theme={{
+          ...defaultTheme,
+          ...(theme as RaThemeOptions),
+        }}
+        layout={Layout}
+      >
+        <Resource
+          name="project"
+          icon={AccountTree}
+          list={ProjectList}
+          edit={ProjectEdit}
+          show={ProjectShow}
+          create={ProjectCreate}
+          recordRepresentation={(record) => record.name || ''}
+        />
+        <Resource
+          name="geofence"
+          icon={Architecture}
+          list={GeofenceList}
+          edit={GeofenceEdit}
+          show={GeofenceShow}
+          create={GeofenceCreate}
+          recordRepresentation={(record) => record.name || ''}
+        />
+        <Resource
+          name="route"
+          icon={Route}
+          list={RouteList}
+          edit={RouteEdit}
+          show={RouteShow}
+          create={RouteCreate}
+          recordRepresentation={(record) => record.name || ''}
+        />
+        <Resource
+          name="property"
+          icon={ListAlt}
+          list={PropertyList}
+          edit={PropertyEdit}
+          show={PropertyShow}
+          create={PropertyCreate}
+          recordRepresentation={(record) => record.name || ''}
+        />
+        <Resource
+          name="tileserver"
+          icon={Map}
+          list={TileServerList}
+          edit={TileServerEdit}
+          show={TileServerShow}
+          create={TileServerCreate}
+          recordRepresentation={(record) => record.name || ''}
+        />
+      </Admin>
+      <NetworkAlert />
+    </>
   )
 }

--- a/docs/pages/api-reference/params.mdx
+++ b/docs/pages/api-reference/params.mdx
@@ -62,6 +62,10 @@ pub struct ApiQueryArgs {
     pub dash: Option<String>,
     /// Replaces any provided string/character with `""` (empty string)
     pub replace: Option<String>,
+    /// Trims x number of characters from the front of the `name` property
+    pub trimstart: Option<u32>,
+    /// Trims x number of characters from the back of the `name` property
+    pub trimend: Option<u32>,
 }
 ```
 
@@ -71,6 +75,8 @@ Since the name property of a geofence may need to be different on a per project 
 
 The manipulations mentioned above are executed in the following order:
 
+1. trimstart
+1. trimend
 1. replace
 1. parentreplace
 1. parentstart

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2029,7 +2029,7 @@ dependencies = [
 
 [[package]]
 name = "model"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "chrono",
  "futures",

--- a/server/model/Cargo.toml
+++ b/server/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "model"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 publish = false
 

--- a/server/model/src/api/args.rs
+++ b/server/model/src/api/args.rs
@@ -73,6 +73,8 @@ pub enum DataPointsArg {
 /// These allow custom modification of the `name` property
 ///
 /// Executed in the following order:
+/// - `trimstart`
+/// - `trimend`
 /// - `replace`
 /// - `parentstart`
 /// - `parentend
@@ -127,6 +129,10 @@ pub struct ApiQueryArgs {
     pub dash: Option<String>,
     /// Replaces any provided string/character with `""` (empty string)
     pub replace: Option<String>,
+    /// Trims x number of characters from the front of the `name` property
+    pub trimstart: Option<usize>,
+    /// Trims x number of characters from the back of the `name` property
+    pub trimend: Option<usize>,
 }
 
 impl Default for ApiQueryArgs {
@@ -151,6 +157,8 @@ impl Default for ApiQueryArgs {
             dash: None,
             replace: None,
             group: None,
+            trimstart: None,
+            trimend: None,
         }
     }
 }

--- a/server/model/src/db/geofence_property.rs
+++ b/server/model/src/db/geofence_property.rs
@@ -159,11 +159,15 @@ impl Query {
         Ok(models)
     }
 
-    pub async fn add_name_property(db: &DatabaseConnection, id: u32) -> Result<Model, ModelError> {
-        let name_property = property::Query::get_or_create_name_record(db).await?;
+    pub async fn add_db_property(
+        db: &DatabaseConnection,
+        id: u32,
+        prop: &str,
+    ) -> Result<Model, ModelError> {
+        let property = property::Query::get_or_create_db_prop(db, prop).await?;
         Query::upsert(
             db,
-            &json!({ "property_id": name_property.id, "geofence_id": id, }),
+            &json!({ "property_id": property.id, "geofence_id": id, }),
             None,
         )
         .await

--- a/server/model/src/db/property.rs
+++ b/server/model/src/db/property.rs
@@ -177,9 +177,12 @@ impl Query {
         Ok(record)
     }
 
-    pub async fn get_or_create_name_record(db: &DatabaseConnection) -> Result<Model, DbErr> {
+    pub async fn get_or_create_db_prop(
+        db: &DatabaseConnection,
+        prop: &str,
+    ) -> Result<Model, DbErr> {
         let record = Entity::find()
-            .filter(property::Column::Name.eq("name"))
+            .filter(property::Column::Name.eq(prop))
             .filter(property::Column::Category.eq("database"))
             .one(db)
             .await?;
@@ -187,7 +190,7 @@ impl Query {
             Ok(record)
         } else {
             ActiveModel {
-                name: Set("name".to_string()),
+                name: Set(prop.to_string()),
                 category: Set(Category::Database),
                 ..Default::default()
             }

--- a/server/model/src/utils/mod.rs
+++ b/server/model/src/utils/mod.rs
@@ -200,7 +200,12 @@ pub fn clean(param: &String) -> String {
 
 pub fn name_modifier(string: String, modifiers: &ApiQueryArgs, parent: Option<String>) -> String {
     let mut mutable = string.clone();
-
+    if let Some(trimfront) = modifiers.trimstart {
+        mutable = (&mutable[trimfront..]).to_string();
+    }
+    if let Some(trimback) = modifiers.trimend {
+        mutable = (&mutable[..(mutable.len() - trimback)]).to_string();
+    }
     if let Some(replacer) = modifiers.replace.as_ref() {
         mutable = mutable.replace(clean(replacer).as_str(), "");
     }
@@ -262,7 +267,7 @@ pub fn name_modifier(string: String, modifiers: &ApiQueryArgs, parent: Option<St
     if modifiers.uppercase.is_some() {
         mutable = mutable.to_uppercase();
     }
-    mutable.trim().to_string();
+    mutable = mutable.trim().to_string();
     if mutable == "" {
         log::warn!(
             "Empty string detected for {} {:?}, returning the standard name",


### PR DESCRIPTION
- Fixes select/deselect all in the import wizard
- Adds support for setting a parent via the import wizard (string or u32)
- Auto adds parent property
- add `trimstart` and `trimend` for extra query params
- fixes pushing to rdm