### PR TITLE
fix count in polygon popup

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "koji",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Tool to make RDM routes",
   "main": "server/dist/index.js",
   "author": "TurtIeSocks <58572875+TurtIeSocks@users.noreply.github.com>",


### PR DESCRIPTION
- Polygon popup was previously not sending the user set `last_seen` value to the server to properly count the number of data points within the polygon bounds