### PR TITLE
add points column

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "koji",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Tool to make RDM routes",
   "main": "server/dist/index.js",
   "author": "TurtIeSocks <58572875+TurtIeSocks@users.noreply.github.com>",

--- a/client/src/assets/types.ts
+++ b/client/src/assets/types.ts
@@ -139,6 +139,7 @@ export interface KojiRoute extends BasicKojiEntry {
   mode: KojiModes
   description?: string
   geometry: MultiPoint
+  points: number
 }
 
 export interface KojiTileServer extends BasicKojiEntry {

--- a/client/src/pages/admin/route/RouteFilter.tsx
+++ b/client/src/pages/admin/route/RouteFilter.tsx
@@ -36,6 +36,22 @@ export function RouteFilter() {
             <FilterListItem key={mode} label={mode} value={{ mode }} />
           ))}
         </FilterList>
+        <FilterList label="Points" icon={<AutoModeIcon />}>
+          {[0, 1, 5, 10, 25].map((count, i, arr) => (
+            <FilterListItem
+              key={count}
+              label={`${(count * 1000).toLocaleString()} ${
+                i === arr.length - 1
+                  ? '<'
+                  : `- ${(arr[i + 1] * 1000).toLocaleString()}`
+              }`}
+              value={{
+                pointsmin: count * 1000,
+                pointsmax: i === arr.length - 1 ? undefined : arr[i + 1] * 1000,
+              }}
+            />
+          ))}
+        </FilterList>
         <FilterList label="Geofence" icon={<SupervisedUserCircleIcon />}>
           <div style={{ maxHeight: 400, overflow: 'auto' }}>
             {(data?.data || []).map((fence) => (

--- a/client/src/pages/admin/route/RouteForm.tsx
+++ b/client/src/pages/admin/route/RouteForm.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
 import {
   FormDataConsumer,
+  FunctionField,
   ReferenceInput,
   SelectInput,
   TextInput,
 } from 'react-admin'
-import { Box } from '@mui/material'
+import { Box, TextField } from '@mui/material'
 
 import { RDM_ROUTES, UNOWN_ROUTES } from '@assets/constants'
 import type { KojiRoute } from '@assets/types'
@@ -30,6 +31,24 @@ export default function RouteForm() {
         optionValue="mode"
       />
       <ReferenceInput source="geofence_id" reference="geofence" isRequired />
+      <FunctionField<KojiRoute>
+        label="Points"
+        render={(fence) => {
+          const points: number =
+            typeof fence?.geometry === 'string'
+              ? JSON.parse(fence?.geometry || '{}')?.coordinates?.length || 0
+              : fence?.geometry?.coordinates?.length || 0
+          return (
+            <TextField
+              value={points}
+              disabled
+              fullWidth
+              size="small"
+              helperText="Point Count"
+            />
+          )
+        }}
+      />
       <CodeInput
         source="geometry"
         label="Route"

--- a/client/src/pages/admin/route/RouteList.tsx
+++ b/client/src/pages/admin/route/RouteList.tsx
@@ -52,7 +52,7 @@ export default function RouteList() {
           <TextField source="description" />
           <TextField source="mode" />
           <ReferenceField source="geofence_id" reference="geofence" />
-          <NumberField source="hops" label="Hops" sortable={false} />
+          <NumberField source="points" label="Points" />
           <EditButton />
           <PushToProd
             resource="route"

--- a/client/src/pages/admin/route/RouteShow.tsx
+++ b/client/src/pages/admin/route/RouteShow.tsx
@@ -22,6 +22,7 @@ export default function RouteShow() {
         <TextField source="description" />
         <TextField source="mode" />
         <ReferenceField source="geofence_id" reference="geofence" />
+        <TextField source="points" />
         <FunctionField<KojiRoute>
           label="Preview"
           render={(route) => (route ? <RouteMap formData={route} /> : null)}

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "koji"
-version = "1.1.4"
+version = "1.2.0"
 dependencies = [
  "api",
  "dotenv",
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "migration"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "async-std",
  "geojson",
@@ -2073,7 +2073,7 @@ dependencies = [
 
 [[package]]
 name = "model"
-version = "1.1.4"
+version = "1.2.0"
 dependencies = [
  "chrono",
  "futures",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koji"
-version = "1.1.4"
+version = "1.2.0"
 edition = "2021"
 
 [workspace]

--- a/server/migration/Cargo.toml
+++ b/server/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "migration"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 publish = false
 

--- a/server/migration/src/lib.rs
+++ b/server/migration/src/lib.rs
@@ -18,6 +18,7 @@ mod m20230221_130117_geofence_mode_enums;
 mod m20230221_143509_route_mode_enums;
 mod m20230301_051446_tile_server_table;
 mod m20230407_045757_parent_column;
+mod m20230505_150751_hop_count;
 
 pub struct Migrator;
 
@@ -43,6 +44,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230221_143509_route_mode_enums::Migration),
             Box::new(m20230301_051446_tile_server_table::Migration),
             Box::new(m20230407_045757_parent_column::Migration),
+            Box::new(m20230505_150751_hop_count::Migration),
         ]
     }
 }

--- a/server/migration/src/m20230505_150751_hop_count.rs
+++ b/server/migration/src/m20230505_150751_hop_count.rs
@@ -1,0 +1,42 @@
+use sea_orm_migration::{
+    prelude::*,
+    sea_orm::{ConnectionTrait, Statement},
+};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute(Statement::from_string(
+                manager.get_database_backend(),
+                r#"ALTER TABLE `route` 
+                ADD COLUMN `points` MEDIUMINT unsigned 
+                    GENERATED ALWAYS AS (
+                        JSON_LENGTH(JSON_EXTRACT(geometry, '$.coordinates'))
+                    ) STORED
+                "#
+                .to_owned(),
+            ))
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute(Statement::from_string(
+                manager.get_database_backend(),
+                r#"ALTER TABLE `route` 
+                DROP COLUMN `points`
+                "#
+                .to_owned(),
+            ))
+            .await?;
+        Ok(())
+    }
+}

--- a/server/model/Cargo.toml
+++ b/server/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "model"
-version = "1.1.4"
+version = "1.2.0"
 edition = "2021"
 publish = false
 

--- a/server/model/src/api/args.rs
+++ b/server/model/src/api/args.rs
@@ -603,6 +603,8 @@ pub struct AdminReq {
     pub mode: Option<String>,
     pub parent: Option<u32>,
     pub geofenceid: Option<u32>,
+    pub pointsmin: Option<u32>,
+    pub pointsmax: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -623,6 +625,8 @@ impl AdminReq {
             mode: self.mode,
             parent: self.parent,
             geofenceid: self.geofenceid,
+            pointsmin: self.pointsmin,
+            pointsmax: self.pointsmax,
         }
     }
 }
@@ -639,4 +643,6 @@ pub struct AdminReqParsed {
     pub mode: Option<String>,
     pub parent: Option<u32>,
     pub geofenceid: Option<u32>,
+    pub pointsmin: Option<u32>,
+    pub pointsmax: Option<u32>,
 }


### PR DESCRIPTION
- add a virtual points column in the route table for more convenient sorting, filtering, querying, etc
- change from `hops` to `points` in client
- add filtering options for different ranges
- version bumps