### PR TITLE
Update Map.tsx

### DIFF
--- a/client/src/components/Map.tsx
+++ b/client/src/components/Map.tsx
@@ -36,8 +36,8 @@ const Map = React.forwardRef<L.Map, Props>(
         zoomControl={zoomControl}
         style={style}
         maxBounds={[
-          [-90, -210],
-          [90, 210],
+          [-85, -180],
+          [85, 180],
         ]}
       >
         {!renderOwnTileLayer && (


### PR DESCRIPTION
Set proper boundaries, so leaflet doesn't over rotate and start providing wrong coordinates.
This also properly fixes the 44.9 latittude issue where it starts skipping it and creating as -45 instead.