### PR TITLE
fix: improved project api support

### DIFF
--- a/server/api/src/public/v1/project.rs
+++ b/server/api/src/public/v1/project.rs
@@ -39,7 +39,6 @@ async fn push_to_prod(
         .await
         .map_err(actix_web::error::ErrorInternalServerError)?;
 
-    log::error!("Scanner Type: {:?}", project);
     let (inserts, updates) = if project.scanner {
         if scanner_type == "rdm" {
             instance::Query::upsert_from_geometry(

--- a/server/api/src/public/v1/project.rs
+++ b/server/api/src/public/v1/project.rs
@@ -25,7 +25,7 @@ async fn push_to_prod(
 
     let features = geofence::Query::project_as_feature(
         &conn.koji_db,
-        id,
+        id.clone(),
         &ApiQueryArgs {
             name: Some(true),
             mode: Some(true),
@@ -35,30 +35,38 @@ async fn push_to_prod(
     .await
     .map_err(actix_web::error::ErrorInternalServerError)?;
 
-    let (inserts, updates) = if scanner_type == "rdm" {
-        instance::Query::upsert_from_geometry(
-            &conn.data_db,
-            GeoFormats::FeatureVec(features),
-            false,
-        )
-        .await
-    } else {
-        area::Query::upsert_from_geometry(
-            &conn.unown_db.as_ref().unwrap(),
-            GeoFormats::FeatureVec(features),
-        )
-        .await
-    }
-    .map_err(actix_web::error::ErrorInternalServerError)?;
-
-    let project = project::Query::get_scanner_project(&conn.koji_db)
+    let project = project::Query::get_one(&conn.koji_db, id)
         .await
         .map_err(actix_web::error::ErrorInternalServerError)?;
-    if let Some(project) = project {
-        send_api_req(project, Some(scanner_type))
+
+    log::error!("Scanner Type: {:?}", project);
+    let (inserts, updates) = if project.scanner {
+        if scanner_type == "rdm" {
+            instance::Query::upsert_from_geometry(
+                &conn.data_db,
+                GeoFormats::FeatureVec(features),
+                false,
+            )
             .await
-            .map_err(actix_web::error::ErrorInternalServerError)?;
-    }
+        } else {
+            area::Query::upsert_from_geometry(
+                &conn.unown_db.as_ref().unwrap(),
+                GeoFormats::FeatureVec(features),
+            )
+            .await
+        }
+        .map_err(actix_web::error::ErrorInternalServerError)?
+    } else {
+        (0, 0)
+    };
+    let scanner_type = if project.scanner {
+        scanner_type.to_string()
+    } else {
+        String::from("other")
+    };
+    send_api_req(project, Some(&scanner_type))
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     log::info!("Rows Updated: {}, Rows Inserted: {}", updates, inserts);
 
     Ok(HttpResponse::Ok().json(Response {

--- a/server/api/src/utils/request.rs
+++ b/server/api/src/utils/request.rs
@@ -25,6 +25,7 @@ pub async fn send_api_req(
             if let Some(scanner_type) = scanner_type {
                 let req = if let Some(api_key) = project.api_key {
                     if let Some((username, password)) = api_key.split_once(":") {
+                        let (username, password) = (username.trim(), password.trim());
                         if scanner_type.eq("rdm") {
                             req.get(endpoint).basic_auth(username, Some(password))
                         } else {


### PR DESCRIPTION
- Improve project API support by adding support for non scanner projects, e.g. calling ReactMap to call the Koji API and refresh in memory areas
- api keys should be treated as if they're a header: `react-map-secret: your_secret`
- Tested with https://github.com/WatWowMap/ReactMap/pull/802