### PR TITLE
feat: hybrid db setup

### DIFF
--- a/client/src/assets/types.ts
+++ b/client/src/assets/types.ts
@@ -211,7 +211,7 @@ export interface Config {
   start_lat: number
   start_lon: number
   tile_server: string
-  scanner_type: string
+  scanner_type: 'rdm' | 'unown' | 'hybrid'
   logged_in: boolean
   dangerous: boolean
 }

--- a/client/src/components/buttons/SaveToScanner.tsx
+++ b/client/src/components/buttons/SaveToScanner.tsx
@@ -11,12 +11,12 @@ export default function SaveToScanner({ fc, ...rest }: Props) {
   const [loading, setLoading] = React.useState(false)
   return (
     <Button
-      disabled={useStatic.getState().scannerType === 'rdm' || loading}
-      onClick={() => {
+      disabled={useStatic.getState().scannerType !== 'unown' || loading}
+      onClick={async () => {
         setLoading(true)
-        return save('/api/v1/geofence/save-scanner', fc)
-          .then(() => getScannerCache())
-          .then(() => setLoading(false))
+        await save('/api/v1/geofence/save-scanner', fc)
+        await getScannerCache()
+        return setLoading(false)
       }}
       {...rest}
     >

--- a/client/src/components/dialogs/import/AssignStep.tsx
+++ b/client/src/components/dialogs/import/AssignStep.tsx
@@ -104,7 +104,14 @@ const AssignStep = React.forwardRef<
         }),
     [nameProp, routeMode],
   )
-
+  const modes =
+    scannerType === 'unown'
+      ? routeMode
+        ? UNOWN_ROUTES
+        : UNOWN_FENCES
+      : routeMode
+      ? RDM_ROUTES
+      : RDM_FENCES
   return (
     <Grid2 container ref={ref} sx={{ width: '100%' }}>
       <Grid2 xs={1} mt={1} />
@@ -183,14 +190,7 @@ const AssignStep = React.forwardRef<
           }}
         >
           <MenuItem value="" />
-          {(scannerType === 'rdm'
-            ? routeMode
-              ? RDM_ROUTES
-              : RDM_FENCES
-            : routeMode
-            ? UNOWN_ROUTES
-            : UNOWN_FENCES
-          ).map((mode) => (
+          {modes.map((mode) => (
             <MenuItem key={mode} value={mode}>
               {mode}
             </MenuItem>
@@ -425,14 +425,7 @@ const AssignStep = React.forwardRef<
                       }}
                     >
                       <MenuItem value="" />
-                      {(scannerType === 'rdm'
-                        ? routeMode
-                          ? RDM_ROUTES
-                          : RDM_FENCES
-                        : routeMode
-                        ? UNOWN_ROUTES
-                        : UNOWN_FENCES
-                      ).map((instanceType) => (
+                      {modes.map((instanceType) => (
                         <MenuItem key={instanceType} value={instanceType}>
                           {instanceType}
                         </MenuItem>

--- a/client/src/components/dialogs/import/ImportStep.tsx
+++ b/client/src/components/dialogs/import/ImportStep.tsx
@@ -91,7 +91,7 @@ const ImportStep = React.forwardRef<
             )
           }}
           controlled
-          filters={scannerType === 'rdm' ? RDM_FENCES : UNOWN_FENCES}
+          filters={scannerType === 'unown' ? UNOWN_FENCES : RDM_FENCES}
           initialState={geojson.features
             .filter((feat) => feat.properties?.__scanner)
             .map((feat) => feat.id as KojiKey)}

--- a/client/src/components/drawer/Routing.tsx
+++ b/client/src/components/drawer/Routing.tsx
@@ -124,7 +124,7 @@ export default function RoutingTab() {
       <Toggle
         field="save_to_scanner"
         label="Save to Scanner Db"
-        disabled={scannerType === 'rdm'}
+        disabled={scannerType !== 'unown'}
       />
       <Toggle field="skipRendering" />
       <ListItemButton

--- a/client/src/hooks/useStatic.ts
+++ b/client/src/hooks/useStatic.ts
@@ -7,6 +7,7 @@ import type {
   FeatureCollection,
   StoreNoFn,
   KojiTileServer,
+  Config,
 } from '@assets/types'
 import { collectionToObject } from '@services/utils'
 import { ALL_FENCES, ALL_ROUTES } from '@assets/constants'
@@ -34,7 +35,7 @@ export interface UseStatic {
   tileServers: KojiTileServer[]
   kojiRoutes: { name: string; id: number; type: string }[]
   scannerRoutes: { name: string; id: number; type: string }[]
-  scannerType: string
+  scannerType: Config['scanner_type']
   dangerous: boolean
   geojson: FeatureCollection
   layerEditing: {

--- a/client/src/pages/admin/geofence/GeofenceFilter.tsx
+++ b/client/src/pages/admin/geofence/GeofenceFilter.tsx
@@ -61,8 +61,8 @@ export function GeofenceFilter() {
         </FilterList>
         <FilterList label="Mode" icon={<AutoModeIcon />}>
           {[
-            ...(scannerType === 'rdm' ? RDM_FENCES : UNOWN_FENCES),
             'unset',
+            ...(scannerType === 'unown' ? UNOWN_FENCES : RDM_FENCES),
           ].map((mode) => (
             <FilterListItem key={mode} label={mode} value={{ mode }} />
           ))}

--- a/client/src/pages/admin/geofence/GeofenceForm.tsx
+++ b/client/src/pages/admin/geofence/GeofenceForm.tsx
@@ -59,7 +59,7 @@ export default function GeofenceForm() {
       <TextInput source="name" fullWidth required />
       <SelectInput
         source="mode"
-        choices={(scannerType === 'rdm' ? RDM_FENCES : UNOWN_FENCES).map(
+        choices={(scannerType === 'unown' ? UNOWN_FENCES : RDM_FENCES).map(
           (mode, i) => ({ id: i, mode }),
         )}
         optionText="mode"

--- a/client/src/pages/admin/project/ProjectForm.tsx
+++ b/client/src/pages/admin/project/ProjectForm.tsx
@@ -14,9 +14,9 @@ export default function ProjectForm() {
         source="api_endpoint"
         fullWidth
         helperText={
-          scannerType === 'rdm'
-            ? 'Hint! For RDM use this format: http://{host_ip}:{port}/api/set_data?reload_instances=true'
-            : 'http://{host_ip}:{port}/reload'
+          scannerType === 'unown'
+            ? 'Hint! For Unown use this format: http://{host_ip}:{port}/reload'
+            : 'Hint! For RDM use this format: http://{host_ip}:{port}/api/set_data?reload_instances=true'
         }
         sx={{ my: 2 }}
       />
@@ -24,9 +24,9 @@ export default function ProjectForm() {
         source="api_key"
         fullWidth
         helperText={
-          scannerType === 'rdm'
-            ? 'Hint! For RDM use this format: {username}:{password}'
-            : ''
+          scannerType === 'unown'
+            ? 'Hint! For Unown use this format: {header_name}:{api_key}'
+            : 'Hint! For RDM use this format: {username}:{password}'
         }
         sx={{ my: 2 }}
       />

--- a/client/src/pages/admin/route/RouteFilter.tsx
+++ b/client/src/pages/admin/route/RouteFilter.tsx
@@ -30,7 +30,7 @@ export function RouteFilter() {
         <FilterLiveSearch />
         <FilterList label="Mode" icon={<AutoModeIcon />}>
           {[
-            ...(scannerType === 'rdm' ? RDM_ROUTES : UNOWN_ROUTES),
+            ...(scannerType === 'unown' ? UNOWN_ROUTES : RDM_ROUTES),
             'unset',
           ].map((mode) => (
             <FilterListItem key={mode} label={mode} value={{ mode }} />

--- a/client/src/pages/admin/route/RouteForm.tsx
+++ b/client/src/pages/admin/route/RouteForm.tsx
@@ -24,7 +24,7 @@ export default function RouteForm() {
       <TextInput source="description" fullWidth />
       <SelectInput
         source="mode"
-        choices={(scannerType === 'rdm' ? RDM_ROUTES : UNOWN_ROUTES).map(
+        choices={(scannerType === 'unown' ? UNOWN_ROUTES : RDM_ROUTES).map(
           (mode, i) => ({ id: i, mode }),
         )}
         optionText="mode"

--- a/client/src/pages/map/popups/Point.tsx
+++ b/client/src/pages/map/popups/Point.tsx
@@ -101,9 +101,9 @@ export function PointPopup({ id, lat, lon, type: geoType, dbRef }: Props) {
               updateProperty(feature.geometry.type, feature.id, '__mode', mode)
             }
           >
-            {(useStatic.getState().scannerType === 'rdm'
-              ? RDM_ROUTES
-              : UNOWN_ROUTES
+            {(useStatic.getState().scannerType === 'unown'
+              ? UNOWN_ROUTES
+              : RDM_ROUTES
             ).map((t) => (
               <MenuItem key={t} value={t}>
                 {t}

--- a/client/src/pages/map/popups/Polygon.tsx
+++ b/client/src/pages/map/popups/Polygon.tsx
@@ -183,9 +183,9 @@ export function PolygonPopup({
               updateProperty(feature.geometry.type, feature.id, '__mode', mode)
             }
           >
-            {(useStatic.getState().scannerType === 'rdm'
-              ? RDM_FENCES
-              : UNOWN_FENCES
+            {(useStatic.getState().scannerType === 'unown'
+              ? UNOWN_FENCES
+              : RDM_FENCES
             ).map((t) => (
               <MenuItem key={t} value={t}>
                 {t}

--- a/client/src/services/utils.ts
+++ b/client/src/services/utils.ts
@@ -268,11 +268,11 @@ export function getRouteType(category: Category): KojiRouteModes {
   const { scannerType } = useStatic.getState()
   switch (category) {
     case 'gym':
-      return scannerType === 'rdm' ? 'circle_smart_raid' : 'circle_raid'
+      return scannerType === 'unown' ? 'circle_raid' : 'circle_smart_raid'
     case 'pokestop':
       return 'circle_quest'
     default:
-      return scannerType === 'rdm' ? 'circle_smart_pokemon' : 'circle_pokemon'
+      return scannerType === 'unown' ? 'circle_pokemon' : 'circle_smart_pokemon'
   }
 }
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -7,7 +7,7 @@ services:
     environment:
       # Required
       SCANNER_DB_URL: 'mysql://rdm_user:rdm_password@host:3306/rdm_database'
-      # UNOWN_DB_URL: 'mysql://rdm_user:rdm_password@host:3306/flygon_database'
+      # CONTROLLER_DB_URL: 'mysql://rdm_user:rdm_password@host:3306/flygon_database'
       KOJI_DB_URL: 'mysql://koji_user:koji_password@127.0.0.1:3306/koji_database'
       KOJI_SECRET: 'your_super_secret'
       # Optional

--- a/docs/pages/setup/docker.mdx
+++ b/docs/pages/setup/docker.mdx
@@ -18,37 +18,43 @@ services:
     restart: unless-stopped
     environment:
       # To escape special characters you must surround the values with single quotes ('')
-      # Required
+      # Commented out variables are optional
+
       # Your Golbat or RDM database
       SCANNER_DB_URL: 'mysql://rdm_user:rdm_password@host:3306/rdm_database'
-      # Your Flygon database - leave commented out for RDM
-      # UNOWN_DB_URL: 'mysql://flygon_user:flygon_password@host:3306/flygon_database'
+
+      # Your Flygon (if using) or RDM database (if you're using a hybrid Golbat/RDM setup)
+      # CONTROLLER_DB_URL: 'mysql://flygon_user:flygon_password@host:3306/flygon_database'
+
       # Your Koji database
       KOJI_DB_URL: 'mysql://koji_user:koji_password@127.0.0.1:3306/koji_database'
+
+      # Max Database connections
+      # MAX_CONNECTIONS: 100
+
       # Your Koji API bearer token and client password
       KOJI_SECRET: 'your_super_secret'
 
-      # Optional
-
       # Start latitude on initial client load
-      #START_LAT: 0
+      # START_LAT: 0
       # Start longitude on initial client load
-      #START_LON: 0
+      # START_LON: 0
       # Nominatim URl used for searching and importing geofences from OSM
-      #NOMINATIM_URL: 'https://nominatim.openstreetmap.org' # highly recommended using your own
-      # Max Database connections
-      #MAX_CONNECTIONS: 100
-      # Logging level
-      #LOG_LEVEL: info # error | warn | info | debug | trace
+      # NOMINATIM_URL: 'https://nominatim.openstreetmap.org' # highly recommended using your own
+      # Logging level | error | warn | info | debug | trace
+      # LOG_LEVEL: info
 
     # Memory limit for docker container
-    #mem_limit: 2048G
+    # mem_limit: 2048G
     # Memory reservation for docker container
-    #mem_reservation: 256M
+    # mem_reservation: 256M
     # CPU limit for docker container
-    #cpus: 2
+    # cpus: 2
+
     ports:
       - '8080:8080' # change left one for external port
+
+
     # Optional: Might be required if your database is also hosted in docker
     # network_mode: "host"
     # extra_hosts:

--- a/docs/pages/setup/standard.mdx
+++ b/docs/pages/setup/standard.mdx
@@ -45,35 +45,38 @@ import { Callout } from 'nextra-theme-docs'
 
 1.  Edit the env file: `nano .env`:
 
-    ```bash
-    # To escape special characters you must surround the values with single quotes ('')
-    # Required
+    ```
+        # To escape special characters you must surround the values with single quotes ('')
+        # Commented out variables are optional
 
-    # Your Golbat or RDM database
-    SCANNER_DB_URL='mysql://rdm_user:rdm_password@127.0.0.1:3306/rdm_database'
-    # Your Flygon database - leave commented out for RDM
-    # UNOWN_DB_URL='mysql://unown_user:unown_password@127.0.0.1:3306/flygon_database'
-    # Your Koji database
-    KOJI_DB_URL='mysql://koji_user:koji_password@127.0.0.1:3306/koji_database'
-    # Your Koji API bearer token and client password
-    KOJI_SECRET='your_super_secret_password'
+        # Your Golbat or RDM database
+        SCANNER_DB_URL='mysql://rdm_user:rdm_password@host:3306/rdm_database'
 
-    # Optional
-    # Host machine
-    HOST='0.0.0.0'
-    # Host port
-    PORT='8080'
-    # Start latitude on initial load
-    START_LAT='0'
-    # Start longitude on initial load
-    START_LON='0'
-    # Max database connections
-    MAX_CONNECTIONS=100
-    # Nominatim URl used for searching and importing geofences from OSM
-    # highly recommended using your own
-    NOMINATIM_URL='https://nominatim.openstreetmap.org'
-    # Logging level
-    LOG_LEVEL='info' # error | warn | info | debug | trace
+        # Your Flygon (if using) or RDM database (if you're using a hybrid Golbat/RDM setup)
+        # CONTROLLER_DB_URL='mysql://flygon_user:flygon_password@host:3306/flygon_database'
+
+        # Your Koji database
+        KOJI_DB_URL='mysql://koji_user:koji_password@127.0.0.1:3306/koji_database'
+
+        # Max Database connections
+        # MAX_CONNECTIONS=100
+
+        # Your Koji API bearer token and client password
+        KOJI_SECRET='your_super_secret'
+
+        # Host address
+        # HOST='0.0.0.0'
+        # Host port
+        # PORT='8080'
+
+        # Start latitude on initial client load
+        # START_LAT=0
+        # Start longitude on initial client load
+        # START_LON=0
+        # Nominatim URl used for searching and importing geofences from OSM
+        # NOMINATIM_URL='https://nominatim.openstreetmap.org' # highly recommended using your own
+        # Logging level | error | warn | info | debug | trace
+        # LOG_LEVEL=info
     ```
 
 1.  Compile the client:

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,6 +1,6 @@
 # Required
 SCANNER_DB_URL='mysql://rdm_user:rdm_password@127.0.0.1:3306/rdm_database'
-# UNOWN_DB_URL='mysql://unown_user:unown_password@127.0.0.1:3306/flygon_database'
+# CONTROLLER_DB_URL='mysql://unown_user:unown_password@127.0.0.1:3306/flygon_database'
 KOJI_DB_URL='mysql://koji_user:koji_password@127.0.0.1:3306/koji_database'
 KOJI_SECRET='your_super_secret_password'
 

--- a/server/api/src/lib.rs
+++ b/server/api/src/lib.rs
@@ -26,7 +26,7 @@ mod utils;
 pub async fn start() -> io::Result<()> {
     let databases = model::utils::get_database_struct().await;
 
-    match Migrator::up(&databases.koji_db, None).await {
+    match Migrator::up(&databases.koji, None).await {
         Ok(_) => log::info!("Migrations successful"),
         Err(err) => log::error!("Migration Error {:?}", err),
     };
@@ -53,18 +53,10 @@ pub async fn start() -> io::Result<()> {
         )
         .unwrap();
 
-        let scanner_type = if databases.unown_db.is_none() {
-            "rdm"
-        } else {
-            "unown"
-        }
-        .to_string();
-
         App::new()
             .app_data(web::Data::new(databases.clone()))
-            .app_data(web::Data::new(scanner_type))
             .app_data(web::Data::new(client))
-            // increase max payload size to 20MB
+            // increase max payload size to 50MB
             .app_data(web::JsonConfig::default().limit(1024 * 1024 * 50))
             .wrap(middleware::Logger::new("%s | %r - %b bytes in %D ms (%a)"))
             .wrap(middleware::Compress::default())

--- a/server/api/src/private/admin.rs
+++ b/server/api/src/private/admin.rs
@@ -24,11 +24,11 @@ async fn paginate(
     let resource = path.into_inner();
 
     let paginated_results = match resource.to_lowercase().as_str() {
-        "geofence" => db::geofence::Query::paginate(&db.koji_db, parsed).await,
-        "project" => db::project::Query::paginate(&db.koji_db, parsed).await,
-        "property" => db::property::Query::paginate(&db.koji_db, parsed).await,
-        "route" => db::route::Query::paginate(&db.koji_db, parsed).await,
-        "tileserver" => db::tile_server::Query::paginate(&db.koji_db, parsed).await,
+        "geofence" => db::geofence::Query::paginate(&db.koji, parsed).await,
+        "project" => db::project::Query::paginate(&db.koji, parsed).await,
+        "property" => db::property::Query::paginate(&db.koji, parsed).await,
+        "route" => db::route::Query::paginate(&db.koji, parsed).await,
+        "tileserver" => db::tile_server::Query::paginate(&db.koji, parsed).await,
         _ => Err(DbErr::Custom("Invalid Resource".to_string())),
     }
     .map_err(actix_web::error::ErrorInternalServerError)?;
@@ -50,8 +50,8 @@ async fn parent_list(
     let resource = path.into_inner();
 
     let results = match resource.to_lowercase().as_str() {
-        "geofence" => db::geofence::Query::unique_parents(&db.koji_db).await,
-        "route" => db::route::Query::unique_geofence(&db.koji_db).await,
+        "geofence" => db::geofence::Query::unique_parents(&db.koji).await,
+        "route" => db::route::Query::unique_geofence(&db.koji).await,
         _ => Err(ModelError::Custom("Invalid Resource".to_string())),
     }
     .map_err(actix_web::error::ErrorInternalServerError)?;
@@ -73,11 +73,11 @@ async fn get_all(
     let resource = path.into_inner();
 
     let results = match resource.to_lowercase().as_str() {
-        "geofence" => db::geofence::Query::get_json_cache(&db.koji_db).await,
-        "project" => db::project::Query::get_json_cache(&db.koji_db).await,
-        "property" => db::property::Query::get_json_cache(&db.koji_db).await,
-        "route" => db::route::Query::get_json_cache(&db.koji_db).await,
-        "tileserver" => db::tile_server::Query::get_json_cache(&db.koji_db).await,
+        "geofence" => db::geofence::Query::get_json_cache(&db.koji).await,
+        "project" => db::project::Query::get_json_cache(&db.koji).await,
+        "property" => db::property::Query::get_json_cache(&db.koji).await,
+        "route" => db::route::Query::get_json_cache(&db.koji).await,
+        "tileserver" => db::tile_server::Query::get_json_cache(&db.koji).await,
         _ => Err(DbErr::Custom("Invalid Resource".to_string())),
     }
     .map_err(actix_web::error::ErrorInternalServerError)?;
@@ -99,11 +99,11 @@ async fn get_one(
     let (resource, id) = path.into_inner();
 
     let result = match resource.to_lowercase().as_str() {
-        "geofence" => db::geofence::Query::get_one_json_with_related(&db.koji_db, id).await,
-        "project" => db::project::Query::get_one_json_with_related(&db.koji_db, id).await,
-        "property" => db::property::Query::get_one_json(&db.koji_db, id).await,
-        "route" => db::route::Query::get_one_json(&db.koji_db, id).await,
-        "tileserver" => db::tile_server::Query::get_one_json(&db.koji_db, id).await,
+        "geofence" => db::geofence::Query::get_one_json_with_related(&db.koji, id).await,
+        "project" => db::project::Query::get_one_json_with_related(&db.koji, id).await,
+        "property" => db::property::Query::get_one_json(&db.koji, id).await,
+        "route" => db::route::Query::get_one_json(&db.koji, id).await,
+        "tileserver" => db::tile_server::Query::get_one_json(&db.koji, id).await,
         _ => Err(ModelError::Custom("Invalid Resource".to_string())),
     }
     .map_err(actix_web::error::ErrorInternalServerError)?;
@@ -127,11 +127,11 @@ async fn create(
     let resource = path.into_inner();
 
     let result = match resource.to_lowercase().as_str() {
-        "geofence" => db::geofence::Query::upsert_json_return(&db.koji_db, 0, payload).await,
-        "project" => db::project::Query::upsert_json_return(&db.koji_db, 0, payload).await,
-        "property" => db::property::Query::upsert_json_return(&db.koji_db, 0, payload).await,
-        "route" => db::route::Query::upsert_json_return(&db.koji_db, 0, payload).await,
-        "tileserver" => db::tile_server::Query::upsert_json_return(&db.koji_db, 0, payload).await,
+        "geofence" => db::geofence::Query::upsert_json_return(&db.koji, 0, payload).await,
+        "project" => db::project::Query::upsert_json_return(&db.koji, 0, payload).await,
+        "property" => db::property::Query::upsert_json_return(&db.koji, 0, payload).await,
+        "route" => db::route::Query::upsert_json_return(&db.koji, 0, payload).await,
+        "tileserver" => db::tile_server::Query::upsert_json_return(&db.koji, 0, payload).await,
         _ => Err(ModelError::Custom("Invalid Resource".to_string())),
     }
     .map_err(actix_web::error::ErrorInternalServerError)?;
@@ -155,11 +155,11 @@ async fn update(
     let payload = payload.into_inner();
 
     let result = match resource.to_lowercase().as_str() {
-        "geofence" => db::geofence::Query::upsert_json_return(&db.koji_db, id, payload).await,
-        "project" => db::project::Query::upsert_json_return(&db.koji_db, id, payload).await,
-        "property" => db::property::Query::upsert_json_return(&db.koji_db, id, payload).await,
-        "route" => db::route::Query::upsert_json_return(&db.koji_db, id, payload).await,
-        "tileserver" => db::tile_server::Query::upsert_json_return(&db.koji_db, id, payload).await,
+        "geofence" => db::geofence::Query::upsert_json_return(&db.koji, id, payload).await,
+        "project" => db::project::Query::upsert_json_return(&db.koji, id, payload).await,
+        "property" => db::property::Query::upsert_json_return(&db.koji, id, payload).await,
+        "route" => db::route::Query::upsert_json_return(&db.koji, id, payload).await,
+        "tileserver" => db::tile_server::Query::upsert_json_return(&db.koji, id, payload).await,
         _ => Err(ModelError::Custom("Invalid Resource".to_string())),
     }
     .map_err(actix_web::error::ErrorInternalServerError)?;
@@ -181,11 +181,11 @@ async fn remove(
     let (resource, id) = path.into_inner();
 
     let result = match resource.to_lowercase().as_str() {
-        "geofence" => db::geofence::Query::delete(&db.koji_db, id).await,
-        "project" => db::project::Query::delete(&db.koji_db, id).await,
-        "property" => db::property::Query::delete(&db.koji_db, id).await,
-        "route" => db::route::Query::delete(&db.koji_db, id).await,
-        "tileserver" => db::tile_server::Query::delete(&db.koji_db, id).await,
+        "geofence" => db::geofence::Query::delete(&db.koji, id).await,
+        "project" => db::project::Query::delete(&db.koji, id).await,
+        "property" => db::property::Query::delete(&db.koji, id).await,
+        "route" => db::route::Query::delete(&db.koji, id).await,
+        "tileserver" => db::tile_server::Query::delete(&db.koji, id).await,
         _ => Err(DbErr::Custom("Invalid Resource".to_string())),
     }
     .map_err(actix_web::error::ErrorInternalServerError)?;
@@ -211,7 +211,7 @@ async fn assign(
     let (resource, property, id) = path.into_inner();
 
     let results = match resource.to_lowercase().as_str() {
-        "geofence" => db::geofence::Query::assign(&db.koji_db, id, property, payload).await,
+        "geofence" => db::geofence::Query::assign(&db.koji, id, property, payload).await,
         // "project" => db::project::Query::search(&db.koji_db, search.query).await,
         // "property" => db::property::Query::search(&db.koji_db, search.query).await,
         // "route" => db::route::Query::search(&db.koji_db, search.query).await,
@@ -238,11 +238,11 @@ async fn search(
     let resource = path.into_inner();
 
     let results = match resource.to_lowercase().as_str() {
-        "geofence" => db::geofence::Query::search(&db.koji_db, search.query).await,
-        "project" => db::project::Query::search(&db.koji_db, search.query).await,
-        "property" => db::property::Query::search(&db.koji_db, search.query).await,
-        "route" => db::route::Query::search(&db.koji_db, search.query).await,
-        "tileserver" => db::tile_server::Query::search(&db.koji_db, search.query).await,
+        "geofence" => db::geofence::Query::search(&db.koji, search.query).await,
+        "project" => db::project::Query::search(&db.koji, search.query).await,
+        "property" => db::property::Query::search(&db.koji, search.query).await,
+        "route" => db::route::Query::search(&db.koji, search.query).await,
+        "tileserver" => db::tile_server::Query::search(&db.koji, search.query).await,
         _ => Err(DbErr::Custom("Invalid Resource".to_string())),
     }
     .map_err(actix_web::error::ErrorInternalServerError)?;

--- a/server/api/src/private/geofence_project.rs
+++ b/server/api/src/private/geofence_project.rs
@@ -10,7 +10,7 @@ use crate::{
 
 #[get("/all/")]
 async fn get_all(conn: web::Data<KojiDb>) -> Result<HttpResponse, Error> {
-    let items = geofence_project::Query::get_all(&conn.koji_db)
+    let items = geofence_project::Query::get_all(&conn.koji)
         .await
         .map_err(actix_web::error::ErrorInternalServerError)?;
 
@@ -29,7 +29,7 @@ async fn create(
     payload: web::Json<geofence_project::Model>,
 ) -> Result<HttpResponse, Error> {
     let payload = payload.into_inner();
-    let return_payload = geofence_project::Query::create(&conn.koji_db, payload)
+    let return_payload = geofence_project::Query::create(&conn.koji, payload)
         .await
         .map_err(actix_web::error::ErrorInternalServerError)?;
 
@@ -56,7 +56,7 @@ async fn update(
     let payload = payload.into_inner();
 
     let result =
-        geofence_project::Query::update(&conn.koji_db, payload.geofence_id, payload.project_id)
+        geofence_project::Query::update(&conn.koji, payload.geofence_id, payload.project_id)
             .await
             .map_err(actix_web::error::ErrorInternalServerError)?;
 
@@ -79,7 +79,7 @@ async fn update_by_id(
     let payload = payload.into_inner();
 
     if table == "geofence" || table == "project" {
-        geofence_project::Query::update_by_id(&conn.koji_db, id, table, payload)
+        geofence_project::Query::update_by_id(&conn.koji, id, table, payload)
             .await
             .map_err(actix_web::error::ErrorInternalServerError)?;
     }
@@ -100,7 +100,7 @@ async fn remove(
 ) -> Result<HttpResponse, Error> {
     let payload = payload.into_inner();
     let projects =
-        geofence_project::Query::delete(&conn.koji_db, payload.geofence_id, payload.project_id)
+        geofence_project::Query::delete(&conn.koji, payload.geofence_id, payload.project_id)
             .await
             .map_err(actix_web::error::ErrorInternalServerError)?;
 

--- a/server/api/src/private/instance.rs
+++ b/server/api/src/private/instance.rs
@@ -3,6 +3,7 @@ use super::*;
 use model::{
     api::{args::ApiQueryArgs, collection::Default},
     db::{route, NameTypeId},
+    ScannerType,
 };
 use serde::Deserialize;
 use serde_json::json;
@@ -16,26 +17,17 @@ use crate::{
 };
 
 #[get("/from_scanner")]
-async fn from_scanner(
-    conn: web::Data<KojiDb>,
-    scanner_type: web::Data<String>,
-) -> Result<HttpResponse, Error> {
-    let scanner_type = scanner_type.to_string();
+async fn from_scanner(conn: web::Data<KojiDb>) -> Result<HttpResponse, Error> {
+    log::info!("\n[INSTANCE-ALL] Scanner Type: {}", conn.scanner_type);
 
-    println!("\n[INSTANCE-ALL] Scanner Type: {}", scanner_type);
-
-    let instances = if scanner_type.eq("rdm") {
-        instance::Query::get_json_cache(&conn.data_db).await
-    } else if let Some(unown_db) = conn.unown_db.as_ref() {
-        area::Query::all(unown_db).await
+    let instances = if conn.scanner_type == ScannerType::Unown {
+        area::Query::all(&conn.controller).await
     } else {
-        Err(DbErr::Custom(
-            "[DB] Scanner is not configured correctly".to_string(),
-        ))
+        instance::Query::get_json_cache(&conn.controller).await
     }
     .map_err(actix_web::error::ErrorInternalServerError)?;
 
-    println!("[INSTANCE_ALL] Returning {} instances\n", instances.len());
+    log::info!("[INSTANCE_ALL] Returning {} instances\n", instances.len());
     Ok(HttpResponse::Ok().json(Response {
         data: Some(json!(instances)),
         message: "ok".to_string(),
@@ -46,15 +38,10 @@ async fn from_scanner(
 }
 
 #[get("/from_koji")]
-async fn from_koji(
-    conn: web::Data<KojiDb>,
-    scanner_type: web::Data<String>,
-) -> Result<HttpResponse, Error> {
-    let scanner_type = scanner_type.to_string();
+async fn from_koji(conn: web::Data<KojiDb>) -> Result<HttpResponse, Error> {
+    log::info!("\n[INSTANCE-ALL] Scanner Type: {}", conn.scanner_type);
 
-    println!("\n[INSTANCE-ALL] Scanner Type: {}", scanner_type);
-
-    let fences = geofence::Query::get_all_no_fences(&conn.koji_db)
+    let fences = geofence::Query::get_all_no_fences(&conn.koji)
         .await
         .map_err(actix_web::error::ErrorInternalServerError)?;
     let mut fences: Vec<NameTypeId> = fences
@@ -67,7 +54,7 @@ async fn from_koji(
         })
         .collect();
 
-    let routes = route::Query::get_all_no_fences(&conn.koji_db)
+    let routes = route::Query::get_all_no_fences(&conn.koji)
         .await
         .map_err(actix_web::error::ErrorInternalServerError)?;
     routes.into_iter().for_each(|instance| {
@@ -79,7 +66,7 @@ async fn from_koji(
         })
     });
 
-    println!("[INSTANCE_ALL] Returning {} instances\n", fences.len());
+    log::info!("[INSTANCE_ALL] Returning {} instances\n", fences.len());
     Ok(HttpResponse::Ok().json(Response {
         data: Some(json!(fences)),
         message: "ok".to_string(),
@@ -100,9 +87,7 @@ struct UrlVars {
 async fn route_from_db(
     conn: web::Data<KojiDb>,
     instance: actix_web::web::Path<UrlVars>,
-    scanner_type: web::Data<String>,
 ) -> Result<HttpResponse, Error> {
-    let scanner_type = scanner_type.to_string();
     let UrlVars {
         source,
         id,
@@ -110,12 +95,10 @@ async fn route_from_db(
     } = instance.into_inner();
 
     let feature = if source.eq("scanner") {
-        if scanner_type.eq("rdm") {
-            instance::Query::feature(&conn.data_db, id).await
-        } else if let Some(unown_db) = conn.unown_db.as_ref() {
-            area::Query::feature(unown_db, id, instance_type).await
+        if conn.scanner_type == ScannerType::Unown {
+            area::Query::feature(&conn.controller, id, instance_type).await
         } else {
-            Ok(Feature::default())
+            instance::Query::feature(&conn.controller, id).await
         }
     } else {
         if instance_type.eq("circle_pokemon")
@@ -124,19 +107,14 @@ async fn route_from_db(
             || instance_type.eq("circle_raid")
             || instance_type.eq("circle_smart_raid")
         {
-            route::Query::feature(&conn.koji_db, id, true).await
+            route::Query::feature(&conn.koji, id, true).await
         } else {
-            geofence::Query::get_one_feature(
-                &conn.koji_db,
-                id.to_string(),
-                &ApiQueryArgs::default(),
-            )
-            .await
+            geofence::Query::get_one_feature(&conn.koji, id.to_string(), &ApiQueryArgs::default())
+                .await
         }
     }
     .map_err(actix_web::error::ErrorInternalServerError)?;
 
-    // println!("[INSTANCE_ALL] Returning {} instances\n", instances.len());
     Ok(HttpResponse::Ok().json(Response {
         data: Some(json!(feature)),
         message: "ok".to_string(),

--- a/server/api/src/private/misc.rs
+++ b/server/api/src/private/misc.rs
@@ -9,12 +9,12 @@ use actix_session::Session;
 use actix_web::http::header;
 
 use geojson::Value;
-use model::api::args::Auth;
+use model::{api::args::Auth, KojiDb};
 use serde_json::json;
 
 #[get("/")]
-async fn config(scanner_type: web::Data<String>, session: Session) -> Result<HttpResponse, Error> {
-    let scanner_type = scanner_type.as_ref().to_string();
+async fn config(conn: web::Data<KojiDb>, session: Session) -> Result<HttpResponse, Error> {
+    let scanner_type = conn.scanner_type.clone();
     let start_lat: f64 = std::env::var("START_LAT")
         .unwrap_or("0.0".to_string())
         .parse()

--- a/server/api/src/private/points.rs
+++ b/server/api/src/private/points.rs
@@ -11,56 +11,54 @@ use model::{
 #[post("/all/{category}")]
 async fn all(
     conn: web::Data<KojiDb>,
-    scanner_type: web::Data<String>,
     category: actix_web::web::Path<String>,
     payload: web::Json<Args>,
 ) -> Result<HttpResponse, Error> {
     let ArgsUnwrapped { last_seen, tth, .. } = payload.into_inner().init(Some("all_data"));
     let category = category.into_inner();
-    let scanner_type = scanner_type.as_ref();
 
-    println!(
+    log::info!(
         "\n[DATA_ALL] Scanner Type: {} | Category: {}",
-        scanner_type, category
+        conn.scanner_type,
+        category
     );
 
     let all_data = match category.as_str() {
-        "gym" => gym::Query::all(&conn.data_db, last_seen).await,
-        "pokestop" => pokestop::Query::all(&conn.data_db, last_seen).await,
-        "spawnpoint" => spawnpoint::Query::all(&conn.data_db, last_seen, tth).await,
+        "gym" => gym::Query::all(&conn.scanner, last_seen).await,
+        "pokestop" => pokestop::Query::all(&conn.scanner, last_seen).await,
+        "spawnpoint" => spawnpoint::Query::all(&conn.scanner, last_seen, tth).await,
         _ => Err(DbErr::Custom("invalid_category".to_string())),
     }
     .map_err(actix_web::error::ErrorInternalServerError)?;
 
-    println!("[DATA-ALL] Returning {} {}s\n", all_data.len(), category);
+    log::info!("[DATA-ALL] Returning {} {}s\n", all_data.len(), category);
     Ok(HttpResponse::Ok().json(all_data))
 }
 
 #[post("/bound/{category}")]
 async fn bound(
     conn: web::Data<KojiDb>,
-    scanner_type: web::Data<String>,
     category: actix_web::web::Path<String>,
     payload: web::Json<BoundsArg>,
 ) -> Result<HttpResponse, Error> {
-    let scanner_type = scanner_type.as_ref();
     let category = category.into_inner();
     let payload = payload.into_inner();
 
-    println!(
+    log::info!(
         "\n[DATA_BOUND] Scanner Type: {} | Category: {}",
-        scanner_type, category
+        conn.scanner_type,
+        category
     );
 
     let bound_data = match category.as_str() {
-        "gym" => gym::Query::bound(&conn.data_db, &payload).await,
-        "pokestop" => pokestop::Query::bound(&conn.data_db, &payload).await,
-        "spawnpoint" => spawnpoint::Query::bound(&conn.data_db, &payload).await,
+        "gym" => gym::Query::bound(&conn.scanner, &payload).await,
+        "pokestop" => pokestop::Query::bound(&conn.scanner, &payload).await,
+        "spawnpoint" => spawnpoint::Query::bound(&conn.scanner, &payload).await,
         _ => Err(DbErr::Custom("invalid_category".to_string())),
     }
     .map_err(actix_web::error::ErrorInternalServerError)?;
 
-    println!(
+    log::info!(
         "[DATA-BOUND] Returning {} {}s\n",
         bound_data.len(),
         category
@@ -71,11 +69,9 @@ async fn bound(
 #[post("/area/{category}")]
 async fn by_area(
     conn: web::Data<KojiDb>,
-    scanner_type: web::Data<String>,
     category: actix_web::web::Path<String>,
     payload: web::Json<Args>,
 ) -> Result<HttpResponse, Error> {
-    let scanner_type = scanner_type.as_ref();
     let category = category.into_inner();
 
     let ArgsUnwrapped {
@@ -88,7 +84,7 @@ async fn by_area(
 
     log::info!(
         "\n[DATA_AREA] Scanner Type: {} | Category: {}",
-        scanner_type,
+        conn.scanner_type,
         category
     );
 
@@ -97,10 +93,9 @@ async fn by_area(
             HttpResponse::BadRequest().json(Response::send_error("no_area_and_empty_instance"))
         );
     }
-    let area =
-        utils::create_or_find_collection(&instance, scanner_type, &conn, area, &None, &vec![])
-            .await
-            .map_err(actix_web::error::ErrorInternalServerError)?;
+    let area = utils::create_or_find_collection(&instance, &conn, area, &None, &vec![])
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
 
     let area_data = utils::points_from_area(&area, &category, &conn, last_seen, tth)
         .await
@@ -113,11 +108,9 @@ async fn by_area(
 #[post("/area_stats/{category}")]
 async fn area_stats(
     conn: web::Data<KojiDb>,
-    scanner_type: web::Data<String>,
     category: actix_web::web::Path<String>,
     payload: web::Json<Args>,
 ) -> Result<HttpResponse, Error> {
-    let scanner_type = scanner_type.as_ref();
     let category = category.into_inner();
 
     let ArgsUnwrapped {
@@ -128,9 +121,10 @@ async fn area_stats(
         ..
     } = payload.into_inner().init(None);
 
-    println!(
+    log::info!(
         "\n[DATA_AREA] Scanner Type: {} | Category: {}",
-        scanner_type, category
+        conn.scanner_type,
+        category
     );
 
     if area.features.is_empty() && instance.is_empty() {
@@ -139,22 +133,22 @@ async fn area_stats(
         );
     }
 
-    let area =
-        utils::create_or_find_collection(&instance, scanner_type, &conn, area, &None, &vec![])
-            .await
-            .map_err(actix_web::error::ErrorInternalServerError)?;
+    let area = utils::create_or_find_collection(&instance, &conn, area, &None, &vec![])
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
 
     let area_data = match category.as_str() {
-        "gym" => gym::Query::stats(&conn.data_db, &area, last_seen).await,
-        "pokestop" => pokestop::Query::stats(&conn.data_db, &area, last_seen).await,
-        "spawnpoint" => spawnpoint::Query::stats(&conn.data_db, &area, last_seen, tth).await,
+        "gym" => gym::Query::stats(&conn.scanner, &area, last_seen).await,
+        "pokestop" => pokestop::Query::stats(&conn.scanner, &area, last_seen).await,
+        "spawnpoint" => spawnpoint::Query::stats(&conn.scanner, &area, last_seen, tth).await,
         _ => Err(DbErr::Custom("Invalid Category".to_string())),
     }
     .map_err(actix_web::error::ErrorInternalServerError)?;
 
-    println!(
+    log::info!(
         "[DATA-AREA] Returning {} Total: {}\n",
-        category, area_data.total
+        category,
+        area_data.total
     );
     Ok(HttpResponse::Ok().json(area_data))
 }

--- a/server/api/src/utils/request.rs
+++ b/server/api/src/utils/request.rs
@@ -26,7 +26,7 @@ pub async fn send_api_req(
                 let req = if let Some(api_key) = project.api_key {
                     if let Some((username, password)) = api_key.split_once(":") {
                         let (username, password) = (username.trim(), password.trim());
-                        if *scanner_type == ScannerType::Unown {
+                        if *scanner_type == ScannerType::Unown || !project.scanner {
                             req.get(endpoint).header(username, password)
                         } else {
                             req.get(endpoint).basic_auth(username, Some(password))

--- a/server/api/src/utils/request.rs
+++ b/server/api/src/utils/request.rs
@@ -4,9 +4,9 @@ use model::db::project;
 
 pub async fn update_project_api(
     db: &KojiDb,
-    scanner_type: Option<&String>,
+    scanner_type: Option<&ScannerType>,
 ) -> Result<reqwest::Response, Error> {
-    let project = project::Query::get_scanner_project(&db.koji_db).await?;
+    let project = project::Query::get_scanner_project(&db.koji).await?;
     if let Some(project) = project {
         send_api_req(project, scanner_type).await
     } else {
@@ -17,7 +17,7 @@ pub async fn update_project_api(
 }
 pub async fn send_api_req(
     project: project::Model,
-    scanner_type: Option<&String>,
+    scanner_type: Option<&ScannerType>,
 ) -> Result<reqwest::Response, Error> {
     if let Some(endpoint) = project.api_endpoint.as_ref() {
         let req = reqwest::ClientBuilder::new().build();
@@ -26,10 +26,10 @@ pub async fn send_api_req(
                 let req = if let Some(api_key) = project.api_key {
                     if let Some((username, password)) = api_key.split_once(":") {
                         let (username, password) = (username.trim(), password.trim());
-                        if scanner_type.eq("rdm") {
-                            req.get(endpoint).basic_auth(username, Some(password))
-                        } else {
+                        if *scanner_type == ScannerType::Unown {
                             req.get(endpoint).header(username, password)
+                        } else {
+                            req.get(endpoint).basic_auth(username, Some(password))
                         }
                     } else {
                         req.get(endpoint)

--- a/server/api/src/utils/response.rs
+++ b/server/api/src/utils/response.rs
@@ -17,7 +17,7 @@ pub struct ConfigResponse {
     pub start_lat: Precision,
     pub start_lon: Precision,
     pub tile_server: String,
-    pub scanner_type: String,
+    pub scanner_type: ScannerType,
     pub logged_in: bool,
     pub dangerous: bool,
 }

--- a/server/model/src/lib.rs
+++ b/server/model/src/lib.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use geojson::{Feature, FeatureCollection};
 use log;
 use sea_orm::DatabaseConnection;
@@ -9,8 +11,53 @@ pub mod error;
 pub mod utils;
 
 #[derive(Debug, Clone)]
+pub enum ScannerType {
+    RDM,
+    Unown,
+    Hybrid,
+}
+
+impl Serialize for ScannerType {
+    fn serialize<S>(
+        &self,
+        serializer: S,
+    ) -> Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            ScannerType::RDM => serializer.serialize_str("rdm"),
+            ScannerType::Unown => serializer.serialize_str("unown"),
+            ScannerType::Hybrid => serializer.serialize_str("hybrid"),
+        }
+    }
+}
+
+impl Display for ScannerType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ScannerType::RDM => write!(f, "rdm"),
+            ScannerType::Unown => write!(f, "unown"),
+            ScannerType::Hybrid => write!(f, "hybrid"),
+        }
+    }
+}
+
+impl PartialEq for ScannerType {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (ScannerType::RDM, ScannerType::RDM) => true,
+            (ScannerType::Unown, ScannerType::Unown) => true,
+            (ScannerType::Hybrid, ScannerType::Hybrid) => true,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct KojiDb {
-    pub koji_db: DatabaseConnection,
-    pub data_db: DatabaseConnection,
-    pub unown_db: Option<DatabaseConnection>,
+    pub koji: DatabaseConnection,
+    pub scanner: DatabaseConnection,
+    pub controller: DatabaseConnection,
+    pub scanner_type: ScannerType,
 }


### PR DESCRIPTION
- This adds better support for those running hybrid RDM/Golbat setups
- `UNOWN_DB_URL` has been deprecated (but is still supported) in favor of `CONTROLLER_DB_URL`
- To utilize, set your `SCANNER_DB_URL` to your Golbat db, then `CONTROLLER_DB_URL` to your RDM db
- Needs testing

Resolves #199 