### PR TITLE
refactor: load stats on demand

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "koji",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "Tool to make RDM routes",
   "main": "server/dist/index.js",
   "author": "TurtIeSocks <58572875+TurtIeSocks@users.noreply.github.com>",

--- a/client/src/components/drawer/Settings.tsx
+++ b/client/src/components/drawer/Settings.tsx
@@ -62,6 +62,7 @@ export default function Settings() {
         <ListItem>
           <Select
             value={tileServer}
+            size="small"
             fullWidth
             onChange={({ target }) => {
               usePersist.setState({ tileServer: target.value })
@@ -81,6 +82,11 @@ export default function Settings() {
           sx={{ px: 2 }}
         />
       )}
+      <Divider sx={{ my: 2 }} />
+      <ListSubheader disableGutters>Max Area to Auto Calc (km²)</ListSubheader>
+      <NumInput field="pokestopMaxAreaAutoCalc" label="Pokestops" />
+      <NumInput field="gymMaxAreaAutoCalc" label="Gyms" />
+      <NumInput field="spawnpointMaxAreaAutoCalc" label="Spawnpoints" />
       {process.env.NODE_ENV === 'development' && (
         <>
           <Divider sx={{ my: 2 }} />

--- a/client/src/components/drawer/inputs/NumInput.tsx
+++ b/client/src/components/drawer/inputs/NumInput.tsx
@@ -13,24 +13,26 @@ export default function NumInput<
   >,
 >({
   field,
+  label,
   endAdornment,
   disabled = false,
   min = 0,
   max = 9999,
 }: {
   field: T
+  label?: string
   disabled?: boolean
   endAdornment?: string
   min?: number
   max?: number
 }) {
   const value = usePersist((s) => s[field])
-
   return (
     <ListItem disabled={disabled}>
       <ListItemText
         primary={
-          field.includes('_') ? fromSnakeCase(field) : fromCamelCase(field)
+          label ??
+          (field.includes('_') ? fromSnakeCase(field) : fromCamelCase(field))
         }
       />
       <TextField

--- a/client/src/hooks/usePersist.ts
+++ b/client/src/hooks/usePersist.ts
@@ -34,6 +34,10 @@ export interface UsePersist {
   simplifyPolygons: boolean
   scaleMarkers: boolean
 
+  // Settings
+  pokestopMaxAreaAutoCalc: number
+  gymMaxAreaAutoCalc: number
+  spawnpointMaxAreaAutoCalc: number
   // Layers
   spawnpoint: boolean
   gym: boolean
@@ -146,6 +150,9 @@ export const usePersist = create(
       setActiveMode: 'hover',
       colorByGeohash: false,
       geohashPrecision: 6,
+      pokestopMaxAreaAutoCalc: 100,
+      gymMaxAreaAutoCalc: 100,
+      spawnpointMaxAreaAutoCalc: 100,
       setStore: (key, value) => set({ [key]: value }),
     }),
     {

--- a/client/src/pages/map/markers/Polygon.tsx
+++ b/client/src/pages/map/markers/Polygon.tsx
@@ -22,8 +22,6 @@ export function KojiPolygon({
 }) {
   const { setStatic } = useStatic.getState()
 
-  const [loadData, setLoadData] = React.useState(false)
-
   const color = getPolygonColor(`${feature.id}`)
 
   return (
@@ -32,7 +30,6 @@ export function KojiPolygon({
       color={color}
       eventHandlers={{
         click({ latlng }) {
-          if (!loadData) setLoadData(true)
           const { lat, lng } = latlng
           setStatic('clickedLocation', [lng, lat])
         },
@@ -145,7 +142,7 @@ export function KojiPolygon({
       pane="polygons"
     >
       <Popup>
-        <MemoPolyPopup feature={feature} loadData={loadData} dbRef={dbRef} />
+        <MemoPolyPopup feature={feature} dbRef={dbRef} />
       </Popup>
     </Polygon>
   )


### PR DESCRIPTION
- Loads Pokestop, Gym, and Spawnpoint stats for an area on demand rather than on popup open

Resolves #197 