### PR TITLE
feat: trim coords for api

### DIFF
--- a/client/src/pages/Playground.tsx
+++ b/client/src/pages/Playground.tsx
@@ -89,6 +89,7 @@ const PROPERTIES = {
   mode: 'boolean',
   parent: 'boolean',
   group: 'boolean',
+  fullcoords: 'boolean',
 }
 
 const PARAMS = {

--- a/server/model/src/api/args.rs
+++ b/server/model/src/api/args.rs
@@ -60,6 +60,8 @@ pub struct ApiQueryArgs {
     pub rt: Option<String>,
     /// If true, the `group` property is set from the parent property
     pub group: Option<bool>,
+    /// If true, the full 64 bit coordinates are used
+    pub fullcoords: Option<bool>,
 
     // -------------------------------------------------------------------------
     // Name Property Manipulation
@@ -108,6 +110,7 @@ impl Default for ApiQueryArgs {
             geofence_id: None,
             parent: None,
             rt: None,
+            fullcoords: None,
             lowercase: None,
             uppercase: None,
             capitalize: None,

--- a/server/model/src/api/collection.rs
+++ b/server/model/src/api/collection.rs
@@ -39,6 +39,21 @@ impl GeometryHelpers for FeatureCollection {
             })
             .collect()
     }
+
+    fn to_f32(self) -> Self {
+        self.into_iter()
+            .map(|feat| {
+                if let Some(geometry) = feat.geometry {
+                    Feature {
+                        geometry: Some(geometry.to_f32()),
+                        ..feat
+                    }
+                } else {
+                    feat
+                }
+            })
+            .collect()
+    }
 }
 
 impl EnsureProperties for FeatureCollection {

--- a/server/model/src/api/mod.rs
+++ b/server/model/src/api/mod.rs
@@ -48,6 +48,7 @@ pub trait ValueHelpers {
 
 pub trait GeometryHelpers {
     fn simplify(self) -> Self;
+    fn to_f32(self) -> Self;
 }
 
 pub trait FeatureHelpers {

--- a/server/model/src/db/geofence.rs
+++ b/server/model/src/db/geofence.rs
@@ -15,6 +15,8 @@ use crate::{
     },
 };
 
+use self::api::GeometryHelpers;
+
 use super::{
     geofence_property::{Basic, FullPropertyModel},
     sea_orm_active_enums::Type,
@@ -202,9 +204,14 @@ impl Model {
                 value: serde_json::Value::from(parent_name.clone()),
             });
         }
+        let geometry = Geometry::from_json_value(self.geometry)?;
 
         let mut feature = Feature {
-            geometry: Some(Geometry::from_json_value(self.geometry)?),
+            geometry: Some(if args.internal.is_some() || args.fullcoords.is_some() {
+                geometry
+            } else {
+                geometry.to_f32()
+            }),
             ..Feature::default()
         };
         for prop in properties.into_iter() {


### PR DESCRIPTION
Trims coords down to 6 digits of precision for API requests to reduce unnecessary payload sizes. Adds a new query argument `fullcords={boolean}` if you want to keep full 64 bit precision.