### PR TITLE
feat: exclude query args

### DIFF
--- a/client/src/pages/Playground.tsx
+++ b/client/src/pages/Playground.tsx
@@ -107,6 +107,9 @@ const PARAMS = {
   underscore: 'string',
   dash: 'string',
   space: 'string',
+  exclude: 'string',
+  excludeparents: 'string',
+  excludeproperties: 'string',
   unpolish: 'boolean',
   ignoremanualparent: 'boolean',
 }

--- a/docs/pages/api-reference/params.mdx
+++ b/docs/pages/api-reference/params.mdx
@@ -69,6 +69,16 @@ pub struct ApiQueryArgs {
     /// If true, all non-alphanumeric characters are removed from the `name` property
     /// (excludes spaces, dashes, and underscores)
     pub alphanumeric: Option<bool>,
+    /// Exclude areas with the specified properties, no matter the value or type.
+    ///
+    /// Property keys separated by a comma
+    pub excludeproperties: Option<String>,
+    /// Excludes areas with the specified parent names
+    ///
+    /// A list of parents names separated by a comma that are to be excluded by the API query
+    pub excludeparents: Option<String>,
+    /// A list of names separated by a comma that are to be excluded by the API query
+    pub exclude: Option<String>,
 }
 ```
 

--- a/server/model/src/api/args.rs
+++ b/server/model/src/api/args.rs
@@ -98,6 +98,16 @@ pub struct ApiQueryArgs {
     /// If true, all non-alphanumeric characters are removed from the `name` property
     /// (excludes spaces, dashes, and underscores)
     pub alphanumeric: Option<bool>,
+    /// Exclude areas with the specified properties, no matter the value or type.
+    ///
+    /// Property keys separated by a comma
+    pub excludeproperties: Option<String>,
+    /// Excludes areas with the specified parent names
+    ///
+    /// A list of parents names separated by a comma that are to be excluded by the API query
+    pub excludeparents: Option<String>,
+    /// A list of names separated by a comma that are to be excluded by the API query
+    pub exclude: Option<String>,
 }
 
 impl Default for ApiQueryArgs {
@@ -128,6 +138,9 @@ impl Default for ApiQueryArgs {
             unpolish: None,
             ignoremanualparent: None,
             alphanumeric: None,
+            excludeproperties: None,
+            excludeparents: None,
+            exclude: None,
         }
     }
 }

--- a/server/model/src/db/geofence.rs
+++ b/server/model/src/db/geofence.rs
@@ -144,7 +144,6 @@ impl Model {
             vec![]
         };
 
-        log::info!("{:?} {}", args.exclude, self.name);
         if separate_by_comma(&args.exclude).contains(&self.name) {
             return Err(ModelError::Geofence("Excluded name".to_string()));
         }

--- a/server/model/src/utils/mod.rs
+++ b/server/model/src/utils/mod.rs
@@ -227,6 +227,14 @@ pub fn json_related_sort(json: &mut Vec<serde_json::Value>, sort_by: &String, or
     });
 }
 
+pub fn separate_by_comma(param: &Option<String>) -> Vec<String> {
+    if let Some(param) = param {
+        param.split(",").map(|x| x.to_string()).collect()
+    } else {
+        vec![]
+    }
+}
+
 fn convert_polish_to_ascii(param: String) -> String {
     let polish_characters: [(char, char); 18] = [
         ('ą', 'a'),


### PR DESCRIPTION
Resolves #219 

Adds:
- `exclude`, excludes any areas by name, separated by a comma. Usage: `exclude=area1,area2,area`
- `excludeparents`, same as by above except parent name
- `excludeproperties`, same as above except by property name, value of the property is not taken into the equation