### PR TITLE
feat: log worst clusters in stats

### DIFF
--- a/server/algorithms/src/stats.rs
+++ b/server/algorithms/src/stats.rs
@@ -211,17 +211,17 @@ impl Stats {
             let mut worst_count = 0;
 
             for cluster in clusters.iter() {
-                if cluster.all.len() > best {
+                let length = cluster.all.len();
+                if length > best {
                     best_clusters.clear();
-                    best = cluster.all.len();
+                    best = length;
                     best_clusters.push(cluster.point.center);
-                } else if cluster.all.len() == best {
+                } else if length == best {
                     best_clusters.push(cluster.point.center);
-                }
-                if cluster.all.len() < worst {
-                    worst = cluster.all.len();
+                } else if length < worst {
+                    worst = length;
                     worst_count = 1;
-                } else if cluster.all.len() == worst {
+                } else if length == worst {
                     worst_count += 1;
                 }
                 if let Some(point) = tree.locate_at_point(&cluster.point.center) {


### PR DESCRIPTION
It's good to know what the lowest number of points are in a cluster, particularly when setting `max_clusters` as an input.

New stats log:
```
      [STATS] =================================================================
      || [AREA] Polygon-645 | Better | Radius                                ||
      || [POINTS] Total: 18988 | Covered: 18283                              ||
      || [CLUSTERS] Total: 888 | Avg Points: 20                              ||
      || [COVERAGE] Best: 77 (1) | Worst: 5 (1)                              ||
      || [DISTANCE] Total: 116525m | Longest: 645m | Avg: 131m               ||
      || [TIMES] Clustering: 5.66s | Routing: 2.32s | Stats: 0.08s           ||
      || [MYGOD_SCORE] 5145                                                  ||
      =========================================================================
```