### PR TITLE
feat: info api route

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "koji",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "Tool to make RDM routes",
   "main": "server/dist/index.js",
   "author": "TurtIeSocks <58572875+TurtIeSocks@users.noreply.github.com>",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "algorithms"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "chrono",
  "colored",
@@ -431,7 +431,7 @@ checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "api"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "actix-files",
  "actix-session",
@@ -2312,7 +2312,7 @@ dependencies = [
 
 [[package]]
 name = "model"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "chrono",
  "futures",

--- a/server/algorithms/Cargo.toml
+++ b/server/algorithms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "algorithms"
-version = "1.2.2"
+version = "1.3.0"
 edition = "2021"
 publish = false
 

--- a/server/algorithms/src/bootstrap/mod.rs
+++ b/server/algorithms/src/bootstrap/mod.rs
@@ -72,3 +72,10 @@ pub fn main(
 pub fn bootstrap_plugins() -> Vec<String> {
     utils::get_plugin_list("algorithms/src/bootstrap/plugins").unwrap_or(vec![])
 }
+
+pub fn all_bootstrap_options() -> Vec<String> {
+    let mut options = bootstrap_plugins();
+    options.push("radius".to_string());
+    options.push("s2".to_string());
+    options
+}

--- a/server/algorithms/src/clustering/mod.rs
+++ b/server/algorithms/src/clustering/mod.rs
@@ -100,3 +100,14 @@ pub fn main(
 pub fn clustering_plugins() -> Vec<String> {
     utils::get_plugin_list("algorithms/src/clustering/plugins").unwrap_or(vec![])
 }
+
+pub fn all_clustering_options() -> Vec<String> {
+    let mut options = clustering_plugins();
+    options.push("honeycomb".to_string());
+    options.push("fastest".to_string());
+    options.push("balanced".to_string());
+    options.push("fast".to_string());
+    options.push("better".to_string());
+    options.push("best".to_string());
+    options
+}

--- a/server/algorithms/src/routing/mod.rs
+++ b/server/algorithms/src/routing/mod.rs
@@ -58,3 +58,13 @@ pub fn main(
 pub fn routing_plugins() -> Vec<String> {
     utils::get_plugin_list("algorithms/src/routing/plugins").unwrap_or(vec![])
 }
+
+pub fn all_routing_options() -> Vec<String> {
+    let mut options = routing_plugins();
+    options.push("point_count".to_string());
+    options.push("latlon".to_string());
+    options.push("geohash".to_string());
+    options.push("s2".to_string());
+    options.push("random".to_string());
+    options
+}

--- a/server/api/Cargo.toml
+++ b/server/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2021"
 publish = false
 

--- a/server/api/src/lib.rs
+++ b/server/api/src/lib.rs
@@ -117,7 +117,9 @@ pub async fn start() -> io::Result<()> {
                 web::scope("/api").service(
                     web::scope("/v1")
                         .wrap(HttpAuthentication::with_fn(auth::public_validator))
-                        .service(web::resource("/health").route(web::get().to(|| HttpResponse::Ok())))
+                        .service(
+                            web::resource("/health").route(web::get().to(|| HttpResponse::Ok())),
+                        )
                         .service(
                             web::scope("/calc")
                                 .service(public::v1::calculate::bootstrap)
@@ -163,7 +165,8 @@ pub async fn start() -> io::Result<()> {
                                 .service(public::v1::s2::cell_coverage)
                                 .service(public::v1::s2::cell_polygons)
                                 .service(public::v1::s2::s2_cells),
-                        ),
+                        )
+                        .service(web::scope("/info").service(public::v1::info::main)),
                 ),
             )
             .service(

--- a/server/api/src/public/v1/info.rs
+++ b/server/api/src/public/v1/info.rs
@@ -1,0 +1,13 @@
+use super::*;
+
+use algorithms::{bootstrap, clustering, routing};
+use serde_json::json;
+
+#[get("/")]
+async fn main() -> Result<HttpResponse, Error> {
+    Ok(HttpResponse::Ok().json(json!({
+        "routing": routing::all_routing_options(),
+        "clustering": clustering::all_clustering_options(),
+        "bootstrap": bootstrap::all_bootstrap_options(),
+    })))
+}

--- a/server/api/src/public/v1/mod.rs
+++ b/server/api/src/public/v1/mod.rs
@@ -3,6 +3,7 @@ use super::*;
 pub mod calculate;
 pub mod convert;
 pub mod geofence;
+pub mod info;
 pub mod project;
 pub mod route;
 pub mod s2;

--- a/server/model/Cargo.toml
+++ b/server/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "model"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
This adds `/api/v1/info/` to get a list of what routing, clustering, and bootstrap options are available. Includes plugins and integrated koji options.