### PR TITLE
feat: export feature cutouts

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "koji",
-  "version": "1.3.14",
+  "version": "1.4.0",
   "description": "Tool to make RDM routes",
   "main": "server/dist/index.js",
   "author": "TurtIeSocks <58572875+TurtIeSocks@users.noreply.github.com>",

--- a/client/src/components/drawer/Drawing.tsx
+++ b/client/src/components/drawer/Drawing.tsx
@@ -17,6 +17,7 @@ export default function DrawingTab() {
       <ListSubheader disableGutters>Drawing</ListSubheader>
       <Toggle field="snappable" />
       <Toggle field="continueDrawing" />
+      <Toggle field="keepCutoutsOnMerge" />
       <UserTextInput field="radius" disabled={calculationMode === 'S2'} />
       <MultiOptionList
         field="setActiveMode"

--- a/client/src/hooks/usePersist.ts
+++ b/client/src/hooks/usePersist.ts
@@ -17,6 +17,7 @@ export interface UsePersist {
   snappable: boolean
   continueDrawing: boolean
   setActiveMode: 'hover' | 'click'
+  keepCutoutsOnMerge: boolean
 
   // Client Settings
   darkMode: boolean
@@ -95,6 +96,7 @@ export const usePersist = create(
       darkMode: true,
       tab: 0,
       drawer: false,
+      keepCutoutsOnMerge: false,
       location: [0, 0],
       zoom: 18,
       category: 'pokestop',

--- a/client/src/pages/map/popups/Polygon.tsx
+++ b/client/src/pages/map/popups/Polygon.tsx
@@ -41,7 +41,11 @@ import {
   splitMultiPolygons,
 } from '@services/utils'
 import { useImportExport } from '@hooks/useImportExport'
-import { filterPoints, filterPolys } from '@services/geoUtils'
+import {
+  filterPoints,
+  filterPolys,
+  getFeatureCutouts,
+} from '@services/geoUtils'
 import { usePersist } from '@hooks/usePersist'
 
 const { add, remove, updateProperty } = useShapes.getState().setters
@@ -311,6 +315,18 @@ export function PolygonPopup({
           }}
         >
           Export
+        </MenuItem>
+        <MenuItem
+          dense
+          onClick={() => {
+            useImportExport.setState({
+              feature: getFeatureCutouts(feature),
+              open: 'exportPolygon',
+            })
+            handleClose()
+          }}
+        >
+          Export Cutouts
         </MenuItem>
         <MenuItem
           dense

--- a/client/src/pages/map/popups/Polygon.tsx
+++ b/client/src/pages/map/popups/Polygon.tsx
@@ -324,14 +324,11 @@ export function PolygonPopup({
               : feature.geometry.coordinates.length < 2
           }
           onClick={() => {
-            useImportExport.setState({
-              feature: getFeatureCutouts(feature),
-              open: 'exportPolygon',
-            })
+            add(getFeatureCutouts(feature))
             handleClose()
           }}
         >
-          Export Cutouts
+          Create Shape from Cutouts
         </MenuItem>
         <MenuItem
           dense

--- a/client/src/pages/map/popups/Polygon.tsx
+++ b/client/src/pages/map/popups/Polygon.tsx
@@ -318,6 +318,11 @@ export function PolygonPopup({
         </MenuItem>
         <MenuItem
           dense
+          disabled={
+            feature.geometry.type === 'MultiPolygon'
+              ? feature.geometry.coordinates.every((c) => c.length < 2)
+              : feature.geometry.coordinates.length < 2
+          }
           onClick={() => {
             useImportExport.setState({
               feature: getFeatureCutouts(feature),

--- a/client/src/services/geoUtils.ts
+++ b/client/src/services/geoUtils.ts
@@ -105,3 +105,43 @@ export function filterPolys(
       remove(value.geometry.type, key)
   })
 }
+
+export function getFeatureCutouts(
+  feature: Feature<Polygon | MultiPolygon>,
+): Feature {
+  const polygons: Polygon[] = []
+
+  if (feature.geometry.type === 'Polygon') {
+    feature.geometry.coordinates.forEach((polygon, i) => {
+      if (i > 0) {
+        polygons.push({
+          type: 'Polygon',
+          coordinates: [polygon],
+        })
+      }
+    })
+  } else if (feature.geometry.type === 'MultiPolygon') {
+    feature.geometry.coordinates.forEach((multi) => {
+      multi.forEach((polygon, i) => {
+        if (i > 0) {
+          polygons.push({
+            type: 'Polygon',
+            coordinates: [polygon],
+          })
+        }
+      })
+    })
+  }
+  return {
+    type: 'Feature',
+    id: `${feature.id}-cutouts`,
+    properties: feature.properties,
+    geometry:
+      polygons.length > 1
+        ? {
+            type: 'MultiPolygon',
+            coordinates: polygons.map((p) => p.coordinates),
+          }
+        : polygons[0],
+  }
+}

--- a/client/src/services/geoUtils.ts
+++ b/client/src/services/geoUtils.ts
@@ -134,6 +134,9 @@ export function getFeatureCutouts(
             type: 'MultiPolygon',
             coordinates: polygons.map((p) => p.coordinates),
           }
-        : polygons[0],
+        : polygons[0] || {
+            type: '',
+            coordinates: [],
+          },
   }
 }

--- a/client/src/services/geoUtils.ts
+++ b/client/src/services/geoUtils.ts
@@ -111,27 +111,19 @@ export function getFeatureCutouts(
 ): Feature {
   const polygons: Polygon[] = []
 
+  const push = (positions: Position[], index: number) =>
+    index > 0 &&
+    polygons.push({
+      type: 'Polygon',
+      coordinates: [positions],
+    })
+
   if (feature.geometry.type === 'Polygon') {
-    feature.geometry.coordinates.forEach((polygon, i) => {
-      if (i > 0) {
-        polygons.push({
-          type: 'Polygon',
-          coordinates: [polygon],
-        })
-      }
-    })
+    feature.geometry.coordinates.forEach(push)
   } else if (feature.geometry.type === 'MultiPolygon') {
-    feature.geometry.coordinates.forEach((multi) => {
-      multi.forEach((polygon, i) => {
-        if (i > 0) {
-          polygons.push({
-            type: 'Polygon',
-            coordinates: [polygon],
-          })
-        }
-      })
-    })
+    feature.geometry.coordinates.forEach((multi) => multi.forEach(push))
   }
+
   return {
     type: 'Feature',
     id: `${feature.id}-cutouts`,


### PR DESCRIPTION
This allows you to export only the cutouts of a given polygon from the koji client. If there's only a single cutout, the resulting export will be a Polygon, otherwise a MultiPolygon.

![Screenshot 2024-07-25 at 9 12 38 AM](https://github.com/user-attachments/assets/34bbda7d-b8f0-4255-998d-812a22c3b77a)
![Screenshot 2024-07-25 at 9 17 09 AM](https://github.com/user-attachments/assets/8f9ee465-471d-4db7-8737-166b263b9ff1)
