### PR TITLE
more consistent usage of precision trait & other formatting refactors

### DIFF
--- a/client/src/components/buttons/Download.tsx
+++ b/client/src/components/buttons/Download.tsx
@@ -3,8 +3,10 @@ import Button, { type ButtonProps } from '@mui/material/Button'
 
 export default function DownloadBtn({
   data,
+  name,
   ...props
-}: ButtonProps & { data: object | string }) {
+}: ButtonProps & { data: object | string; name?: string }) {
+  const safeName = name || 'geojson.json'
   return (
     <Button
       variant="outlined"
@@ -18,7 +20,12 @@ export default function DownloadBtn({
             typeof data === 'string' ? data : JSON.stringify(data, null, 2),
           )}`,
         )
-        el.setAttribute('download', 'geojson.json')
+        el.setAttribute(
+          'download',
+          (safeName.endsWith('.json') ? safeName : `${safeName}.json`)
+            .replaceAll(' ', '-')
+            .toLocaleLowerCase(),
+        )
         el.style.display = 'none'
         document.body.appendChild(el)
         el.click()

--- a/client/src/components/dialogs/ImportExport.tsx
+++ b/client/src/components/dialogs/ImportExport.tsx
@@ -4,7 +4,6 @@ import Button from '@mui/material/Button'
 import Dialog from '@mui/material/Dialog'
 import DialogContent from '@mui/material/DialogContent'
 import Grid2 from '@mui/material/Unstable_Grid2/Grid2'
-import useDeepCompareEffect from 'use-deep-compare-effect'
 
 import SplitMultiPolygonsBtn from '@components/buttons/SplitMultiPolygons'
 import MultiOptions from '@components/drawer/inputs/MultiOptions'
@@ -32,6 +31,8 @@ export function ImportExportDialog({
   const feature = useImportExport((s) => s.feature)
   const code = useImportExport((s) => s.code)
   const error = useImportExport((s) => s.error)
+  const fileName = useImportExport((s) => s.fileName)
+
   const { reset, setCode, fireConvert, updateStats } =
     useImportExport.getState()
 
@@ -46,7 +47,7 @@ export function ImportExportDialog({
     }
   }, [polygonExportMode, open, code, simplifyPolygons])
 
-  useDeepCompareEffect(() => {
+  React.useEffect(() => {
     if (open) {
       if (shape === 'Route') {
         updateStats(mode === 'Export')
@@ -106,7 +107,16 @@ export function ImportExportDialog({
           style={{ flexGrow: 1, display: 'flex', justifyContent: 'flex-end' }}
         >
           <ClipboardButton text={code} />
-          <DownloadBtn data={code} variant="text" color="primary" />
+          <DownloadBtn
+            data={code}
+            variant="text"
+            color="primary"
+            name={
+              fileName ||
+              (feature.type === 'Feature' &&
+                (feature.properties?.__name || feature.properties?.name))
+            }
+          />
           <Button
             disabled={!!error}
             onClick={() => {

--- a/client/src/pages/admin/actions/Export.tsx
+++ b/client/src/pages/admin/actions/Export.tsx
@@ -9,7 +9,12 @@ import {
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { useQuery } from 'react-query'
 
-import { BasicKojiEntry, Feature, KojiResponse } from '@assets/types'
+import type {
+  BasicKojiEntry,
+  Feature,
+  FeatureCollection,
+  KojiResponse,
+} from '@assets/types'
 import { fetchWrapper } from '@services/fetches'
 import { useImportExport } from '@hooks/useImportExport'
 
@@ -39,7 +44,10 @@ export function ExportButton<T extends BasicKojiEntry>({
   const record = useRecordContext<T>()
   const { refetch } = useQuery(
     `export-${resource}-${record.id}`,
-    () => fetchWrapper<KojiResponse<Feature>>(getUrl(resource, record.id)),
+    () =>
+      fetchWrapper<KojiResponse<Feature | FeatureCollection>>(
+        getUrl(resource, record.id),
+      ),
     {
       enabled: false,
     },
@@ -54,6 +62,12 @@ export function ExportButton<T extends BasicKojiEntry>({
             useImportExport.setState({
               open: 'exportPolygon',
               feature: res.data.data,
+              fileName:
+                res.data.data.type === 'Feature'
+                  ? res.data.data.properties?.__name ||
+                    res.data.data.properties?.name ||
+                    ''
+                  : record.name,
             })
           }
         })

--- a/client/src/pages/map/popups/Point.tsx
+++ b/client/src/pages/map/popups/Point.tsx
@@ -63,9 +63,9 @@ export function PointPopup({ id, lat, lon, type: geoType, dbRef }: Props) {
 
   return id !== undefined ? (
     <div>
-      Lat: {lat.toFixed(6)}
+      Lat: {lat}
       <br />
-      Lng: {lon.toFixed(6)}
+      Lng: {lon}
       <br />
       {process.env.NODE_ENV === 'development' && (
         <>

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -431,7 +431,7 @@ checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "api"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "actix-files",
  "actix-session",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "koji"
-version = "1.4.2"
+version = "1.5.1"
 dependencies = [
  "api",
  "dotenv",
@@ -2312,7 +2312,7 @@ dependencies = [
 
 [[package]]
 name = "model"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "chrono",
  "futures",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koji"
-version = "1.4.2"
+version = "1.5.1"
 edition = "2021"
 
 [workspace]

--- a/server/api/Cargo.toml
+++ b/server/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 publish = false
 

--- a/server/api/src/public/v1/convert.rs
+++ b/server/api/src/public/v1/convert.rs
@@ -8,6 +8,7 @@ use model::{
         FeatureHelpers, GeometryHelpers, ToCollection, ToFeature,
     },
     db::sea_orm_active_enums::Type,
+    utils::TrimPrecision,
 };
 
 #[post("/data")]
@@ -21,11 +22,11 @@ async fn convert_data(payload: web::Json<Args>) -> Result<HttpResponse, Error> {
         ..
     } = payload.into_inner().init(Some("convert_data"));
 
-    let area = if arg_simplify { area.simplify() } else { area };
-    let area = area
+    let area = if arg_simplify { area.simplify() } else { area }
         .into_iter()
         .map(|feat| feat.remove_internal_props())
-        .collect();
+        .collect::<FeatureCollection>()
+        .trim_precision(6);
 
     Ok(utils::response::send(
         area,

--- a/server/model/Cargo.toml
+++ b/server/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "model"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 publish = false
 

--- a/server/model/src/api/collection.rs
+++ b/server/model/src/api/collection.rs
@@ -1,3 +1,5 @@
+use utils::TrimPrecision;
+
 use self::utils::sql_raw;
 
 use super::{args::UnknownId, multi_vec::MultiVec, *};
@@ -39,13 +41,15 @@ impl GeometryHelpers for FeatureCollection {
             })
             .collect()
     }
+}
 
-    fn to_f32(self) -> Self {
+impl TrimPrecision for FeatureCollection {
+    fn trim_precision(self, precision: u32) -> Self {
         self.into_iter()
             .map(|feat| {
                 if let Some(geometry) = feat.geometry {
                     Feature {
-                        geometry: Some(geometry.to_f32()),
+                        geometry: Some(geometry.trim_precision(precision)),
                         ..feat
                     }
                 } else {

--- a/server/model/src/api/geometry.rs
+++ b/server/model/src/api/geometry.rs
@@ -1,4 +1,5 @@
 use geo::{MultiPolygon, Polygon, Simplify};
+use utils::TrimPrecision;
 
 use super::*;
 
@@ -37,22 +38,24 @@ impl EnsurePoints for Geometry {
     }
 }
 
-fn trim_precision(data: Vec<Vec<Vec<f64>>>) -> Vec<Vec<Vec<f64>>> {
-    let mut formatted_data = Vec::new();
+impl TrimPrecision for Vec<Vec<Vec<f64>>> {
+    fn trim_precision(self, precision: u32) -> Self {
+        let mut formatted_data = Vec::new();
 
-    for outer_vec in data {
-        let mut formatted_outer_vec = Vec::new();
-        for inner_vec in outer_vec {
-            let mut formatted_inner_vec = Vec::new();
-            for num in inner_vec {
-                formatted_inner_vec.push(format!("{:.6}", num).parse().unwrap());
+        for outer_vec in self {
+            let mut formatted_outer_vec = Vec::new();
+            for inner_vec in outer_vec {
+                let mut formatted_inner_vec = Vec::new();
+                for num in inner_vec {
+                    formatted_inner_vec.push(num.trim_precision(precision));
+                }
+                formatted_outer_vec.push(formatted_inner_vec);
             }
-            formatted_outer_vec.push(formatted_inner_vec);
+            formatted_data.push(formatted_outer_vec);
         }
-        formatted_data.push(formatted_outer_vec);
-    }
 
-    formatted_data
+        formatted_data
+    }
 }
 
 impl GeometryHelpers for Geometry {
@@ -71,13 +74,18 @@ impl GeometryHelpers for Geometry {
         geometry.bbox = geometry.get_bbox();
         geometry
     }
-    fn to_f32(self) -> Self {
+}
+
+impl TrimPrecision for Geometry {
+    fn trim_precision(self, precision: u32) -> Self {
         let mut geometry = match self.value {
-            Value::Polygon(value) => Geometry::from(geojson::Value::Polygon(trim_precision(value))),
+            Value::Polygon(value) => {
+                Geometry::from(geojson::Value::Polygon(value.trim_precision(precision)))
+            }
             Value::MultiPolygon(value) => {
                 let mut formatted_data: Vec<Vec<Vec<Vec<f64>>>> = Vec::new();
                 for outer_vec in value {
-                    formatted_data.push(trim_precision(outer_vec))
+                    formatted_data.push(outer_vec.trim_precision(precision))
                 }
                 Geometry::from(geojson::Value::MultiPolygon(formatted_data))
             }

--- a/server/model/src/api/mod.rs
+++ b/server/model/src/api/mod.rs
@@ -48,7 +48,6 @@ pub trait ValueHelpers {
 
 pub trait GeometryHelpers {
     fn simplify(self) -> Self;
-    fn to_f32(self) -> Self;
 }
 
 pub trait FeatureHelpers {

--- a/server/model/src/api/point_array.rs
+++ b/server/model/src/api/point_array.rs
@@ -76,7 +76,7 @@ impl ToCollection for PointArray {
 
 impl ToText for PointArray {
     fn to_text(self, sep_1: &str, sep_2: &str, _poly_sep: bool) -> String {
-        format!("{}{}{}{}", self[0] as f32, sep_1, self[1] as f32, sep_2)
+        format!("{}{}{}{}", self[0], sep_1, self[1], sep_2)
     }
 }
 

--- a/server/model/src/api/point_struct.rs
+++ b/server/model/src/api/point_struct.rs
@@ -82,7 +82,7 @@ impl ToCollection for PointStruct {
 
 impl ToText for PointStruct {
     fn to_text(self, sep_1: &str, sep_2: &str, _poly_sep: bool) -> String {
-        format!("{}{}{}{}", self.lat as f32, sep_1, self.lon as f32, sep_2)
+        format!("{}{}{}{}", self.lat, sep_1, self.lon, sep_2)
     }
 }
 

--- a/server/model/src/api/single_vec.rs
+++ b/server/model/src/api/single_vec.rs
@@ -1,3 +1,5 @@
+use utils::TrimPrecision;
+
 use super::{collection::Default, *};
 
 pub type SingleVec = Vec<point_array::PointArray>;
@@ -46,7 +48,7 @@ impl GetBbox for SingleVec {
                 bbox[3] = point[0]
             }
         }
-        Some(bbox)
+        Some(bbox.into_iter().map(|e| e.trim_precision(6)).collect())
     }
 }
 

--- a/server/model/src/db/geofence.rs
+++ b/server/model/src/db/geofence.rs
@@ -15,8 +15,6 @@ use crate::{
     },
 };
 
-use self::api::GeometryHelpers;
-
 use super::{
     geofence_property::{Basic, FullPropertyModel},
     sea_orm_active_enums::Type,
@@ -27,6 +25,7 @@ use geojson::{GeoJson, Geometry};
 use sea_orm::{entity::prelude::*, UpdateResult};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use utils::TrimPrecision;
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
 #[sea_orm(table_name = "geofence")]
@@ -233,7 +232,7 @@ impl Model {
             geometry: Some(if args.internal.is_some() || args.fullcoords.is_some() {
                 geometry
             } else {
-                geometry.to_f32()
+                geometry.trim_precision(6)
             }),
             ..Feature::default()
         };


### PR DESCRIPTION
- `TrimPrecision` trait, now with its own arg, more widely implemented, replaces previous `.to_f32` method
- Dynamic names for json file downloads to more appropriately match the content that's being downloaded
- Prevent second fetch request when converting exports
- Trim up some repeated code
- Better formatting (white space) for SQL export type
- Only trim precision for [Multi]Polygons, don't trim for [Multi]Point since the precision is arguably important for those