### PR TITLE
Add functionality to delete geofences via external API

### DIFF
--- a/docs/app/api-reference/endpoints/page.mdx
+++ b/docs/app/api-reference/endpoints/page.mdx
@@ -160,6 +160,11 @@ All routes below are mounted under `/api/v1`.
       <Table.Td>Upserts provided geofences into scanner/controller DB and triggers project API call.</Table.Td>
     </Table.Tr>
     <Table.Tr>
+      <Table.Td>`DELETE`</Table.Td>
+      <Table.Td>`/geofence/{id}`</Table.Td>
+      <Table.Td>Deletes one Koji geofence by numeric id.</Table.Td>
+    </Table.Tr>
+    <Table.Tr>
       <Table.Td>`GET`</Table.Td>
       <Table.Td>`/geofence/push/{id}`</Table.Td>
       <Table.Td>Pushes one Koji geofence to scanner/controller DB and triggers project API call.</Table.Td>

--- a/docs/app/api-reference/params/page.mdx
+++ b/docs/app/api-reference/params/page.mdx
@@ -368,6 +368,12 @@ Used by route endpoints:
       <Table.Td>Return format + project filter.</Table.Td>
     </Table.Tr>
     <Table.Tr>
+      <Table.Td>`/api/v1/geofence/{id}`</Table.Td>
+      <Table.Td>`id`</Table.Td>
+      <Table.Td>integer</Table.Td>
+      <Table.Td>Numeric Koji geofence id to delete.</Table.Td>
+    </Table.Tr>
+    <Table.Tr>
       <Table.Td>`/api/v1/geofence/push/{id}`</Table.Td>
       <Table.Td>`id`</Table.Td>
       <Table.Td>string</Table.Td>

--- a/docs/app/api-reference/scripts/page.mdx
+++ b/docs/app/api-reference/scripts/page.mdx
@@ -67,6 +67,14 @@ curl -sS -X POST \
   }'
 ```
 
+## cURL: Delete a Geofence
+
+```bash
+curl -sS -X DELETE \
+  -H "Authorization: Bearer KOJI_SECRET" \
+  "http://127.0.0.1:8080/api/v1/geofence/42"
+```
+
 ## JavaScript: Sync All Project Geofences to Scanner
 
 ```js

--- a/server/api/src/lib.rs
+++ b/server/api/src/lib.rs
@@ -142,6 +142,7 @@ pub async fn start() -> io::Result<()> {
                                 .service(public::v1::geofence::reference_data_project)
                                 .service(public::v1::geofence::save_koji)
                                 .service(public::v1::geofence::save_scanner)
+                                .service(public::v1::geofence::remove)
                                 .service(public::v1::geofence::push_to_prod)
                                 .service(public::v1::geofence::get_area)
                                 .service(public::v1::geofence::specific_return_type)

--- a/server/api/src/public/v1/geofence.rs
+++ b/server/api/src/public/v1/geofence.rs
@@ -83,6 +83,26 @@ async fn save_koji(
     }))
 }
 
+#[delete("/{id}")]
+async fn remove(
+    conn: web::Data<KojiDb>,
+    id: actix_web::web::Path<u32>,
+) -> Result<HttpResponse, Error> {
+    let id = id.into_inner();
+
+    let result = geofence::Query::delete(&conn.koji, id)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    Ok(HttpResponse::Ok().json(Response {
+        data: Some(json!(result.rows_affected)),
+        message: "Success".to_string(),
+        status: "ok".to_string(),
+        stats: None,
+        status_code: 200,
+    }))
+}
+
 #[post("/save-scanner")]
 async fn save_scanner(
     conn: web::Data<KojiDb>,


### PR DESCRIPTION
Currently, this is only possible through the internal API, but I want to be able to delete geofences from my internal tools.

- Adds a new DELETE `/geofence/{id}` endpoint
- Updates docs