### PR TITLE
feat(greedy): adaptive S2 partitioning for Better/Best modes

### DIFF
--- a/client/src/components/drawer/Routing.tsx
+++ b/client/src/components/drawer/Routing.tsx
@@ -3,9 +3,11 @@ import {
   Collapse,
   Divider,
   List,
+  ListItem,
   ListItemButton,
   ListItemIcon,
   ListItemText,
+  Switch,
 } from '@mui/material'
 import Update from '@mui/icons-material/Update'
 
@@ -151,6 +153,31 @@ export default function RoutingTab() {
           field="genetic_post_processing"
           label="Genetic Post Processing"
         /> */}
+        {/*
+          DEV TOGGLE — remove after PR #253 merges.
+          Bypasses the adaptive S2 partition + post-greedy gap-fill so dev
+          friends can A/B compare quality stats against the pre-PR algorithm.
+          The Toggle component above only supports top-level `usePersist` keys,
+          and the `dev` field is nested for forward-compat, so this is a
+          one-off inline ListItem.
+        */}
+        <ListItem>
+          <ListItemText
+            primary="Bypass Adaptive Partition"
+            secondary="Dev: run pre-PR clustering for A/B comparison"
+          />
+          <Switch
+            edge="end"
+            checked={
+              usePersist((s) => s.dev?.bypass_adaptive_partition) ?? false
+            }
+            onChange={(_e, v) =>
+              usePersist.setState((s) => ({
+                dev: { ...s.dev, bypass_adaptive_partition: v },
+              }))
+            }
+          />
+        </ListItem>
       </Collapse>
 
       <Divider sx={{ my: 2 }} />

--- a/client/src/hooks/usePersist.ts
+++ b/client/src/hooks/usePersist.ts
@@ -80,6 +80,21 @@ export interface UsePersist {
   bootstrapping_args: string
   center_clusters: boolean
   genetic_post_processing: boolean
+  /**
+   * Developer / experimental request toggles. Mirrors the `DevArgs` struct on
+   * the server. Expect this object to grow and shrink between releases. Fields
+   * here are NOT part of the stable public API and may be removed without
+   * notice once the feature they were used to debug is merged.
+   */
+  dev: {
+    /**
+     * When `true`, the server skips the adaptive S2 partitioning + post-greedy
+     * gap-fill added in PR #253 and uses the pre-PR `setup()` path for every
+     * mode. Intended for side-by-side quality comparison during PR review;
+     * will be commented out after the PR merges.
+     */
+    bypass_adaptive_partition: boolean
+  }
   // generations: number | ''
   // routing_time: number | ''
   // devices: number | ''
@@ -132,6 +147,9 @@ export const usePersist = create(
       // routing_chunk_size: 0,
       calculation_mode: 'Radius',
       genetic_post_processing: false,
+      dev: {
+        bypass_adaptive_partition: false,
+      },
       s2_level: 15,
       s2_size: 9,
       max_clusters: 0,

--- a/client/src/services/fetches.ts
+++ b/client/src/services/fetches.ts
@@ -138,6 +138,7 @@ export async function clusteringRouting({
     clustering_args,
     bootstrapping_args,
     genetic_post_processing,
+    dev,
   } = usePersist.getState()
   const { geojson, setStatic, bounds } = useStatic.getState()
   const { add, activeRoute } = useShapes.getState().setters
@@ -255,6 +256,7 @@ export async function clusteringRouting({
             clustering_args,
             bootstrapping_args,
             genetic_post_processing,
+            dev,
           }),
         },
       )

--- a/docs/superpowers/plans/2026-05-27-greedy-bbox-adaptive-partition.md
+++ b/docs/superpowers/plans/2026-05-27-greedy-bbox-adaptive-partition.md
@@ -1,0 +1,1249 @@
+# Greedy Adaptive S2 Partition — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `ClusterMode::Better` and `ClusterMode::Best` from generating tens to hundreds of millions of cluster candidates on huge bboxes by adding an adaptive S2-cell partitioner with halo, ownership filter, and stepwise mode-fallback ladder.
+
+**Architecture:** A new `clustering/partition.rs` module wraps the existing `Greedy::setup` per-chunk. For Better/Best modes, `Greedy::run` calls `run_partitioned`, which adaptively subdivides the input bbox by S2 cell level (starting at level 6, descending to level 18 max) until each chunk's estimated candidate cost fits the budget. Each chunk solves greedy with a `radius`-wide halo overlap and keeps only clusters whose center falls in the owned cell. Cost estimator accounts for the existing grid-density scaling and falls back per chunk to Better → Balanced → Fast for irreducible cases.
+
+**Tech Stack:** Rust 2024 edition, `s2 = "0.0.13"`, `rstar = "0.12.2"`, `rayon = "1.11.0"`, `hashbrown = "0.16.0"`, `sysinfo = "0.37.0"`, `rand = "0.9.2"`, `log = "0.4.28"`.
+
+**Spec:** [docs/superpowers/specs/2026-05-27-greedy-bbox-adaptive-partition-design.md](../specs/2026-05-27-greedy-bbox-adaptive-partition-design.md)
+
+---
+
+## File Map
+
+| Path | Action | Responsibility |
+| --- | --- | --- |
+| `server/algorithms/src/clustering/partition.rs` | Create | Types, config loader, estimator, partitioner, halo, ladder, orchestrator |
+| `server/algorithms/src/clustering/mod.rs` | Modify | Add `mod partition;` |
+| `server/algorithms/src/clustering/greedy.rs` | Modify | Branch `run` for Better/Best → `run_partitioned`; extract `associate_clusters_for_chunk`; deprecation warning on `set_cluster_split_level` |
+
+All new tests live inline in `partition.rs` under `#[cfg(test)] mod tests`. The `algorithms` crate has no existing tests; this plan introduces the first ones.
+
+**Conventions used below:**
+- Run tests with `cargo test -p algorithms` from `server/` (workspace root for cargo).
+- If rayon contention shows up in tests, add `--test-threads=1`.
+- Commits use Conventional Commits (`feat:`, `refactor:`, `test:`, `chore:`).
+- Each task is one bounded TDD cycle and ends with a commit.
+
+**Pre-flight check — verify baseline compiles before starting:**
+
+```bash
+cd server && cargo check -p algorithms
+```
+
+If this fails on `rand` errors (`SmallRng` not in `rngs`, `rand::rng` private), the workspace baseline is broken and unrelated to this plan. Fix `server/algorithms/Cargo.toml` line 21:
+
+```toml
+# from
+rand = { version = "0.9.2", default-features = false }
+# to (minimum to unblock baseline)
+rand = { version = "0.9.2", default-features = false, features = ["small_rng", "std", "std_rng", "thread_rng"] }
+```
+
+Or replace `rand::rng()` (sec/sec.rs:22) with the rand 0.9 equivalent if simpler. Resolve to a clean `cargo check` before proceeding. **This pre-flight is not part of this plan's commits** — fix on a separate branch or commit independently.
+
+---
+
+## Task 1: Bootstrap `partition.rs` module + types + config loader
+
+**Files:**
+- Create: `server/algorithms/src/clustering/partition.rs`
+- Modify: `server/algorithms/src/clustering/mod.rs` (add `mod partition;` and re-export)
+
+- [ ] **Step 1: Create `partition.rs` with bare types**
+
+Create file `server/algorithms/src/clustering/partition.rs`:
+
+```rust
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use model::api::cluster_mode::ClusterMode;
+use model::api::single_vec::SingleVec;
+use s2::cellid::CellID;
+use sysinfo::System;
+
+/// Bytes assumed per candidate when converting memory budget → candidate count.
+/// PointArray (16 bytes) + Cluster<Point> overhead (avg Vec<&Point> tail).
+pub(crate) const BYTES_PER_CANDIDATE: usize = 256;
+
+pub(crate) const DEFAULT_START_LEVEL: u64 = 6;
+pub(crate) const DEFAULT_MAX_LEVEL: u64 = 18;
+
+#[derive(Debug, Clone)]
+pub(crate) struct Chunk {
+    pub cell: CellID,
+    pub owned: SingleVec,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PartitionConfig {
+    pub budget: usize,
+    pub start_level: u64,
+    pub max_level: u64,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct PartitionStats {
+    pub total_chunks: usize,
+    pub downgrades: HashMap<(ClusterMode, ClusterMode), usize>,
+}
+
+static CONFIG: OnceLock<PartitionConfig> = OnceLock::new();
+
+impl PartitionConfig {
+    pub(crate) fn load() -> PartitionConfig {
+        *CONFIG.get_or_init(|| {
+            let sys = System::new_all();
+            let threads = rayon::current_num_threads().max(1) as u64;
+            let mem_per_thread = sys.available_memory() / threads;
+            let auto_budget = (mem_per_thread / BYTES_PER_CANDIDATE as u64) as usize;
+
+            let budget = std::env::var("KOJI_MAX_CANDIDATES_PER_CHUNK")
+                .ok()
+                .and_then(|s| s.parse::<usize>().ok())
+                .unwrap_or(auto_budget);
+            let start_level = std::env::var("KOJI_PARTITION_START_LEVEL")
+                .ok()
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or(DEFAULT_START_LEVEL);
+            let max_level = std::env::var("KOJI_PARTITION_MAX_LEVEL")
+                .ok()
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or(DEFAULT_MAX_LEVEL);
+
+            log::info!(
+                "PartitionConfig: budget={}, start_level={}, max_level={}",
+                budget, start_level, max_level
+            );
+            PartitionConfig { budget, start_level, max_level }
+        })
+    }
+}
+```
+
+- [ ] **Step 2: Add module to clustering/mod.rs**
+
+Edit `server/algorithms/src/clustering/mod.rs` at line 16-20 (the `mod` declarations).
+
+Replace:
+```rust
+mod candidates;
+mod fastest;
+// mod genetic;
+mod greedy;
+mod s2;
+```
+
+With:
+```rust
+mod candidates;
+mod fastest;
+// mod genetic;
+mod greedy;
+mod partition;
+mod s2;
+```
+
+- [ ] **Step 3: Run cargo check to verify compile**
+
+Run: `cargo check -p algorithms`
+Expected: PASS with no errors. Warnings about unused types are OK at this stage.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/algorithms/src/clustering/partition.rs server/algorithms/src/clustering/mod.rs
+git commit -m "feat(clustering): scaffold partition module + config types"
+```
+
+---
+
+## Task 2: Test helpers (random_points_in_bbox, dense_cluster, sparse_grid)
+
+**Files:**
+- Modify: `server/algorithms/src/clustering/partition.rs` (append `#[cfg(test)] mod tests`)
+
+- [ ] **Step 1: Write failing test that uses the helpers**
+
+Append to `server/algorithms/src/clustering/partition.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use model::api::Precision;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+    use rand::Rng;
+
+    pub(super) fn random_points_in_bbox(n: usize, bbox: [Precision; 4], seed: u64) -> SingleVec {
+        let [min_lat, min_lon, max_lat, max_lon] = bbox;
+        let mut rng = SmallRng::seed_from_u64(seed);
+        (0..n)
+            .map(|_| {
+                let lat = rng.random_range(min_lat..max_lat);
+                let lon = rng.random_range(min_lon..max_lon);
+                [lat, lon]
+            })
+            .collect()
+    }
+
+    pub(super) fn dense_cluster(
+        center: [Precision; 2],
+        n: usize,
+        radius_m: Precision,
+        seed: u64,
+    ) -> SingleVec {
+        let mut rng = SmallRng::seed_from_u64(seed);
+        // Approx 1 deg lat ≈ 111_000 m; ignore lon shrinkage for tiny test radii
+        let radius_deg = radius_m / 111_000.0;
+        (0..n)
+            .map(|_| {
+                let dlat = rng.random_range(-radius_deg..radius_deg);
+                let dlon = rng.random_range(-radius_deg..radius_deg);
+                [center[0] + dlat, center[1] + dlon]
+            })
+            .collect()
+    }
+
+    pub(super) fn sparse_grid(
+        rows: usize,
+        cols: usize,
+        bbox: [Precision; 4],
+    ) -> SingleVec {
+        let [min_lat, min_lon, max_lat, max_lon] = bbox;
+        let lat_step = (max_lat - min_lat) / rows as Precision;
+        let lon_step = (max_lon - min_lon) / cols as Precision;
+        (0..rows)
+            .flat_map(|r| {
+                (0..cols).map(move |c| {
+                    [
+                        min_lat + (r as Precision + 0.5) * lat_step,
+                        min_lon + (c as Precision + 0.5) * lon_step,
+                    ]
+                })
+            })
+            .collect()
+    }
+
+    #[test]
+    fn helpers_produce_expected_shapes() {
+        let pts = random_points_in_bbox(100, [0., 0., 1., 1.], 42);
+        assert_eq!(pts.len(), 100);
+        for p in &pts {
+            assert!(p[0] >= 0.0 && p[0] < 1.0);
+            assert!(p[1] >= 0.0 && p[1] < 1.0);
+        }
+
+        let cluster = dense_cluster([10., 20.], 50, 100.0, 7);
+        assert_eq!(cluster.len(), 50);
+
+        let grid = sparse_grid(5, 5, [0., 0., 10., 10.]);
+        assert_eq!(grid.len(), 25);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cargo test -p algorithms --lib clustering::partition::tests::helpers_produce_expected_shapes`
+Expected: PASS.
+
+If `Precision` is not importable from `model::api`, check `/Users/rin/GitHub/Koji/.claude/worktrees/condescending-blackburn-c2cc26/server/model/src/api.rs` for the actual path — it's likely `model::api::Precision` per usage in `candidates.rs:4`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/algorithms/src/clustering/partition.rs
+git commit -m "test(partition): add seeded random/cluster/grid helpers"
+```
+
+---
+
+## Task 3: Cost estimator (distinct_l16_cells, scaled_grid_density, estimate_cost)
+
+**Files:**
+- Modify: `server/algorithms/src/clustering/partition.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Inside the `#[cfg(test)] mod tests` block, add:
+
+```rust
+#[test]
+fn distinct_l16_cells_dedupes() {
+    let points = vec![[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]];
+    assert_eq!(distinct_l16_cells(&points), 1);
+
+    let points = dense_cluster([0., 0.], 10, 1.0, 1);  // 10 points, ~1m radius
+    let n = distinct_l16_cells(&points);
+    assert!(n >= 1 && n <= 10, "expected dedup count between 1 and 10, got {}", n);
+}
+
+#[test]
+fn scaled_grid_density_caps_correctly() {
+    // s2_cost dominates -> density 0
+    assert_eq!(scaled_grid_density(1_000_000, 500_000), 0);
+    // tiny s2 cost, huge budget -> capped at BYTE * 6
+    let big = scaled_grid_density(0, 100_000_000_000);
+    assert_eq!(big, BYTE_TIMES_SIX);
+    // moderate: sqrt(remaining) used
+    let mid = scaled_grid_density(0, 1_000_000);
+    assert_eq!(mid, 1000);
+}
+
+#[test]
+fn estimate_cost_better_excludes_grid() {
+    let points = dense_cluster([0., 0.], 100, 50.0, 2);
+    let est_better = estimate_cost(&points, ClusterMode::Better, 10_000_000);
+    let est_best = estimate_cost(&points, ClusterMode::Best, 10_000_000);
+    assert!(est_best >= est_better, "Best must be >= Better");
+}
+
+#[test]
+fn estimate_cost_best_scales_with_budget() {
+    let points = vec![[0.0, 0.0]];
+    let est_small = estimate_cost(&points, ClusterMode::Best, 100);
+    let est_large = estimate_cost(&points, ClusterMode::Best, 100_000_000);
+    assert!(est_small < est_large, "larger budget should allow larger grid");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p algorithms --lib clustering::partition::tests::distinct_l16_cells_dedupes`
+Expected: FAIL (function not found).
+
+- [ ] **Step 3: Implement the estimator**
+
+Add to `server/algorithms/src/clustering/partition.rs` (above the test module):
+
+```rust
+use s2::latlng::LatLng;
+use std::collections::HashSet as StdHashSet;
+use model::api::Precision;
+use model::api::point_array::PointArray;
+
+/// Existing `BYTE` constant is local to greedy.rs (`const BYTE: usize = 1024`).
+/// We mirror it here rather than expose it: this is the BYTE × 6 grid-density ceiling
+/// used by Best mode in greedy::associate_clusters.
+pub(crate) const BYTE_TIMES_SIX: usize = 1024 * 6;
+
+pub(crate) fn distinct_l16_cells(points: &[PointArray]) -> usize {
+    points
+        .iter()
+        .map(|p| CellID::from(LatLng::from_degrees(p[0], p[1])).parent(16))
+        .collect::<StdHashSet<_>>()
+        .len()
+}
+
+pub(crate) fn scaled_grid_density(s2_cost: usize, budget: usize) -> usize {
+    let remaining = budget.saturating_sub(s2_cost);
+    let density = (remaining as f64).sqrt() as usize;
+    density.min(BYTE_TIMES_SIX)
+}
+
+pub(crate) fn estimate_cost(
+    points: &[PointArray],
+    mode: ClusterMode,
+    budget: usize,
+) -> usize {
+    let s2_cost = distinct_l16_cells(points).saturating_mul(4096); // 4^(22-16)
+    let grid_cost = if matches!(mode, ClusterMode::Best) {
+        scaled_grid_density(s2_cost, budget).pow(2)
+    } else {
+        0
+    };
+    s2_cost.saturating_add(grid_cost)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p algorithms --lib clustering::partition::tests`
+Expected: PASS for all four new tests + helpers test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/algorithms/src/clustering/partition.rs
+git commit -m "feat(partition): cost estimator with grid-density scaling"
+```
+
+---
+
+## Task 4: Cell helpers (cell_bbox_lat_lon, contains_latlng)
+
+**Files:**
+- Modify: `server/algorithms/src/clustering/partition.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to the test module:
+
+```rust
+#[test]
+fn contains_latlng_owns_only_its_cell() {
+    // Pick a stable lat/lon, get its level-10 parent.
+    let center = LatLng::from_degrees(37.7749, -122.4194);  // SF
+    let owning_cell = CellID::from(center).parent(10);
+
+    // The lat/lon itself must be contained.
+    assert!(contains_latlng(owning_cell, [37.7749, -122.4194]));
+
+    // A point on the opposite side of the world is not contained.
+    assert!(!contains_latlng(owning_cell, [-37.7749, 57.5806]));
+}
+
+#[test]
+fn cell_bbox_lat_lon_is_finite_and_ordered() {
+    let center = LatLng::from_degrees(0., 0.);
+    let cell = CellID::from(center).parent(8);
+    let bb = cell_bbox_lat_lon(cell);
+    assert!(bb.min_lat.is_finite() && bb.max_lat.is_finite());
+    assert!(bb.min_lon.is_finite() && bb.max_lon.is_finite());
+    assert!(bb.min_lat <= bb.max_lat);
+    assert!(bb.min_lon <= bb.max_lon);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p algorithms --lib clustering::partition::tests::contains_latlng_owns_only_its_cell`
+Expected: FAIL (function not found).
+
+- [ ] **Step 3: Implement helpers**
+
+Add to `partition.rs` (above the test module):
+
+```rust
+use s2::cell::Cell;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct LatLonBBox {
+    pub min_lat: Precision,
+    pub max_lat: Precision,
+    pub min_lon: Precision,
+    pub max_lon: Precision,
+}
+
+impl LatLonBBox {
+    pub fn center_lat(&self) -> Precision {
+        0.5 * (self.min_lat + self.max_lat)
+    }
+
+    pub fn expand(&self, radius_deg: Precision) -> LatLonBBox {
+        LatLonBBox {
+            min_lat: self.min_lat - radius_deg,
+            max_lat: self.max_lat + radius_deg,
+            min_lon: self.min_lon - radius_deg,
+            max_lon: self.max_lon + radius_deg,
+        }
+    }
+}
+
+pub(crate) fn cell_bbox_lat_lon(cell: CellID) -> LatLonBBox {
+    let c = Cell::from(&cell);
+    // Use vertex extremes; avoids rect_bound() API churn between s2 versions.
+    let mut min_lat = Precision::INFINITY;
+    let mut max_lat = Precision::NEG_INFINITY;
+    let mut min_lon = Precision::INFINITY;
+    let mut max_lon = Precision::NEG_INFINITY;
+    for i in 0..4 {
+        let v = c.vertex(i);
+        let ll = LatLng::from(&v);
+        let lat = ll.lat.deg();
+        let lon = ll.lng.deg();
+        if lat < min_lat { min_lat = lat; }
+        if lat > max_lat { max_lat = lat; }
+        if lon < min_lon { min_lon = lon; }
+        if lon > max_lon { max_lon = lon; }
+    }
+    LatLonBBox { min_lat, max_lat, min_lon, max_lon }
+}
+
+pub(crate) fn contains_latlng(cell: CellID, p: PointArray) -> bool {
+    let derived = CellID::from(LatLng::from_degrees(p[0], p[1])).parent(cell.level());
+    derived == cell
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p algorithms --lib clustering::partition::tests`
+Expected: PASS for all previous tests + 2 new ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/algorithms/src/clustering/partition.rs
+git commit -m "feat(partition): cell bbox + ownership helpers"
+```
+
+---
+
+## Task 5: `adaptive_partition` function
+
+**Files:**
+- Modify: `server/algorithms/src/clustering/partition.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to the test module:
+
+```rust
+#[test]
+fn partition_small_bbox_single_chunk() {
+    // 1000 points in roughly 1km² → should fit in one chunk at start_level=6.
+    let pts = random_points_in_bbox(1000, [37.78, -122.43, 37.79, -122.42], 42);
+    let chunks = adaptive_partition(&pts, usize::MAX, ClusterMode::Better, 6, 18);
+    assert_eq!(chunks.len(), 1, "small bbox should be one chunk, got {}", chunks.len());
+}
+
+#[test]
+fn partition_subdivides_when_over_budget() {
+    // Force subdivision with a tiny budget.
+    let pts = sparse_grid(20, 20, [-30., -60., 30., 60.]);
+    let chunks = adaptive_partition(&pts, 1, ClusterMode::Better, 6, 18);
+    assert!(chunks.len() > 1, "tiny budget should produce many chunks");
+}
+
+#[test]
+fn partition_halts_at_max_level() {
+    // Dense cluster + extremely tight budget → at least one chunk at max_level=18.
+    let pts = dense_cluster([0., 0.], 5_000, 50.0, 11);
+    let chunks = adaptive_partition(&pts, 1, ClusterMode::Best, 6, 18);
+    assert!(
+        chunks.iter().any(|c| c.cell.level() == 18),
+        "expected at least one chunk to reach max_level"
+    );
+}
+
+#[test]
+fn partition_preserves_all_points() {
+    let pts = random_points_in_bbox(500, [0., 0., 5., 5.], 99);
+    let chunks = adaptive_partition(&pts, 1_000_000, ClusterMode::Better, 6, 18);
+    let total: usize = chunks.iter().map(|c| c.owned.len()).sum();
+    assert_eq!(total, pts.len(), "no points should be dropped during partition");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p algorithms --lib clustering::partition::tests::partition_small_bbox_single_chunk`
+Expected: FAIL (function not found).
+
+- [ ] **Step 3: Implement `adaptive_partition`**
+
+Add to `partition.rs` (above the test module):
+
+```rust
+use crate::s2::create_cell_map;
+
+pub(crate) fn adaptive_partition(
+    points: &SingleVec,
+    budget: usize,
+    mode: ClusterMode,
+    start_level: u64,
+    max_level: u64,
+) -> Vec<Chunk> {
+    if points.is_empty() {
+        return vec![];
+    }
+    let mut frontier: HashMap<u64, SingleVec> = create_cell_map(points, start_level);
+    let mut accepted: Vec<Chunk> = Vec::new();
+
+    loop {
+        let mut next_frontier: HashMap<u64, SingleVec> = HashMap::new();
+        for (cell_id_raw, cell_points) in frontier.into_iter() {
+            let cell = CellID(cell_id_raw);
+            let est = estimate_cost(&cell_points, mode, budget);
+            if est <= budget || cell.level() >= max_level {
+                accepted.push(Chunk { cell, owned: cell_points });
+            } else {
+                let children = create_cell_map(&cell_points, cell.level() + 1);
+                for (k, v) in children {
+                    next_frontier.entry(k).or_insert_with(Vec::new).extend(v);
+                }
+            }
+        }
+        if next_frontier.is_empty() {
+            break;
+        }
+        frontier = next_frontier;
+    }
+    accepted
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p algorithms --lib clustering::partition::tests`
+Expected: All passing including 4 new partition tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/algorithms/src/clustering/partition.rs
+git commit -m "feat(partition): adaptive_partition with BFS S2-level descent"
+```
+
+---
+
+## Task 6: `gather_halo` function
+
+**Files:**
+- Modify: `server/algorithms/src/clustering/partition.rs`
+
+- [ ] **Step 1: Write failing test**
+
+Append to the test module:
+
+```rust
+#[test]
+fn gather_halo_includes_nearby_points_outside_cell() {
+    use crate::clustering::rtree::point::Point;
+    use crate::rtree;
+
+    // Pick a level-12 cell; place one point inside, one just outside (within radius).
+    let inside = [37.7749, -122.4194];
+    let cell = CellID::from(LatLng::from_degrees(inside[0], inside[1])).parent(12);
+    let bbox = cell_bbox_lat_lon(cell);
+
+    // Point just past the east edge (10 meters past, well under default 70m radius).
+    let outside = [bbox.max_lat - 0.00001, bbox.max_lon + 0.00005];
+
+    let all_points: SingleVec = vec![inside, outside];
+    let tree = rtree::spawn(70.0, &all_points);
+
+    let halo = gather_halo(cell, &tree, 70.0);
+    assert!(
+        halo.iter().any(|p| (p.center[1] - outside[1]).abs() < 1e-6),
+        "halo should include the just-outside point"
+    );
+    assert!(
+        !halo.iter().any(|p| (p.center[1] - inside[1]).abs() < 1e-6),
+        "halo should NOT include the inside point"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p algorithms --lib clustering::partition::tests::gather_halo_includes_nearby_points_outside_cell`
+Expected: FAIL (function not found).
+
+- [ ] **Step 3: Implement `gather_halo`**
+
+Add to `partition.rs`:
+
+```rust
+use crate::clustering::rtree::point::Point;
+use crate::clustering::candidates;
+use rstar::{RTree, AABB};
+
+pub(crate) fn gather_halo(
+    cell: CellID,
+    all_points_tree: &RTree<Point>,
+    radius_meters: Precision,
+) -> Vec<Point> {
+    let bbox = cell_bbox_lat_lon(cell);
+    let radius_deg = candidates_meters_to_degrees(radius_meters, bbox.center_lat());
+    let expanded = bbox.expand(radius_deg);
+
+    let envelope = AABB::from_corners(
+        [expanded.min_lat, expanded.min_lon],
+        [expanded.max_lat, expanded.max_lon],
+    );
+
+    all_points_tree
+        .locate_in_envelope_intersecting(&envelope)
+        .filter(|p| !contains_latlng(cell, p.center))
+        .cloned()
+        .collect()
+}
+
+/// Thin re-export so we don't depend on `pub` of candidates::meters_to_degrees.
+/// candidates::meters_to_degrees is already `pub fn` (candidates.rs:127), use it directly.
+fn candidates_meters_to_degrees(meters: Precision, lat: Precision) -> Precision {
+    candidates::meters_to_degrees(meters, lat)
+}
+```
+
+Note: `Point` is `#[derive(Debug, Clone, Copy)]` (see `server/algorithms/src/rtree/point.rs:15`), so `.cloned()` works. No special handling needed.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p algorithms --lib clustering::partition::tests::gather_halo_includes_nearby_points_outside_cell`
+Expected: PASS.
+
+If rtree's `locate_in_envelope_intersecting` API differs in version 0.12, consult `rstar = "0.12.2"` docs — equivalent method may be `locate_in_envelope_intersecting_mut` (no-op for our read) or `iter_in_envelope`. Pick the closest match and adjust.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/algorithms/src/clustering/partition.rs
+git commit -m "feat(partition): gather_halo collects boundary points via rtree envelope"
+```
+
+---
+
+## Task 7: `select_effective_mode` (fallback ladder)
+
+**Files:**
+- Modify: `server/algorithms/src/clustering/partition.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to the test module:
+
+```rust
+#[test]
+fn fallback_ladder_keeps_mode_when_under_budget() {
+    let pts = random_points_in_bbox(10, [0., 0., 0.001, 0.001], 1);
+    let mode = select_effective_mode(ClusterMode::Best, &pts, usize::MAX);
+    assert_eq!(mode, ClusterMode::Best);
+}
+
+#[test]
+fn fallback_ladder_walks_down_to_fast() {
+    // Force a chunk that is over budget even at Fast (impossible in practice,
+    // but we set budget = 0 to verify ladder reaches floor).
+    let pts = random_points_in_bbox(50, [-30., -60., 30., 60.], 7);
+    let mode = select_effective_mode(ClusterMode::Best, &pts, 0);
+    assert_eq!(mode, ClusterMode::Fast, "ladder must terminate at Fast");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p algorithms --lib clustering::partition::tests::fallback_ladder_keeps_mode_when_under_budget`
+Expected: FAIL (function not found).
+
+- [ ] **Step 3: Implement `select_effective_mode`**
+
+Add to `partition.rs`:
+
+```rust
+pub(crate) fn select_effective_mode(
+    requested: ClusterMode,
+    points: &[PointArray],
+    budget: usize,
+) -> ClusterMode {
+    let mut current = requested;
+    loop {
+        if matches!(current, ClusterMode::Fast)
+            || estimate_cost(points, current, budget) <= budget
+        {
+            return current;
+        }
+        let next = match current {
+            ClusterMode::Best => ClusterMode::Better,
+            ClusterMode::Better => ClusterMode::Balanced,
+            ClusterMode::Balanced => ClusterMode::Fast,
+            _ => return current,
+        };
+        log::warn!(
+            "chunk over budget for {:?} (est={}, budget={}), downgrading to {:?}",
+            current,
+            estimate_cost(points, current, budget),
+            budget,
+            next,
+        );
+        current = next;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p algorithms --lib clustering::partition::tests`
+Expected: All passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/algorithms/src/clustering/partition.rs
+git commit -m "feat(partition): select_effective_mode stepwise fallback ladder"
+```
+
+---
+
+## Task 8: Refactor `associate_clusters` → expose mode-parameterized variant
+
+**Files:**
+- Modify: `server/algorithms/src/clustering/greedy.rs:157-242`
+
+- [ ] **Step 1: Read current implementation**
+
+Read `server/algorithms/src/clustering/greedy.rs:157-242`. The current `associate_clusters` does mode-based candidate generation (lines 168-181) then filtering, sizing, and bucketing. The bucketing tail is mode-agnostic.
+
+- [ ] **Step 2: Extract candidate generation into a helper that accepts mode + grid_density**
+
+Replace the body of `associate_clusters` (greedy.rs:157-242). Change the signature **of the candidate-generation step** to accept `mode` and `grid_density`, leaving the rest of the body intact.
+
+New helper at module scope (still inside `impl<'a> Greedy`):
+
+```rust
+fn generate_candidates_for_mode(
+    &self,
+    points: &'a SingleVec,
+    point_tree: &'a RTree<Point>,
+    mode: ClusterMode,
+    grid_density_override: Option<usize>,
+) -> SingleVec {
+    const BYTE: usize = 1024;
+    match mode {
+        ClusterMode::Honeycomb => self.get_honeycomb_clusters(points),
+        ClusterMode::Fast => self.gen_clusters(BYTE / 2, points),
+        ClusterMode::Balanced => self.gen_clusters(BYTE, points),
+        ClusterMode::Better | ClusterMode::Best => {
+            let mut pcs = self.get_s2_clusters(points, point_tree);
+            if matches!(mode, ClusterMode::Best) {
+                let density = grid_density_override.unwrap_or(BYTE * 6);
+                if density > 0 {
+                    pcs.extend_from_slice(&self.gen_clusters(density, points));
+                }
+            }
+            pcs
+        }
+        _ => vec![],
+    }
+}
+```
+
+Then update `associate_clusters` to use it:
+
+Replace lines 168-181 (the `let clusters_with_data: Vec<Cluster> = match self.cluster_mode { ... } .into_par_iter() ...`) with:
+
+```rust
+let clusters_with_data: Vec<Cluster> = self
+    .generate_candidates_for_mode(points, point_tree, self.cluster_mode, None)
+    .into_par_iter()
+    .filter_map(|cluster| {
+        let iter = point_tree.locate_all_at_point(&cluster);
+        let mut points = Vec::with_capacity(iter.size_hint().0);
+        points.extend(iter);
+
+        (points.len() >= self.min_points)
+            .then(|| Cluster::new(Point::new(self.radius, 20, cluster), points, vec![]))
+    })
+    .collect();
+```
+
+The rest of `associate_clusters` (memory log, bucketing) is unchanged.
+
+- [ ] **Step 3: Add an `associate_clusters_for_chunk` method**
+
+Add inside `impl<'a> Greedy`, before `setup`:
+
+```rust
+fn associate_clusters_for_chunk(
+    &'a self,
+    points: &'a SingleVec,
+    point_tree: &'a RTree<Point>,
+    effective_mode: ClusterMode,
+    budget: usize,
+) -> Vec<Vec<Cluster<'a>>> {
+    use crate::clustering::partition::{distinct_l16_cells, scaled_grid_density};
+
+    let grid_density = if matches!(effective_mode, ClusterMode::Best) {
+        let s2_cost = distinct_l16_cells(points).saturating_mul(4096);
+        Some(scaled_grid_density(s2_cost, budget))
+    } else {
+        None
+    };
+
+    let raw_candidates = self.generate_candidates_for_mode(
+        points,
+        point_tree,
+        effective_mode,
+        grid_density,
+    );
+
+    let clusters_with_data: Vec<Cluster> = raw_candidates
+        .into_par_iter()
+        .filter_map(|cluster| {
+            let iter = point_tree.locate_all_at_point(&cluster);
+            let mut points = Vec::with_capacity(iter.size_hint().0);
+            points.extend(iter);
+
+            (points.len() >= self.min_points)
+                .then(|| Cluster::new(Point::new(self.radius, 20, cluster), points, vec![]))
+        })
+        .collect();
+
+    // Reuse the bucketing tail from associate_clusters. The cleanest way is to extract
+    // it into a method `bucket_clusters_by_size`; for now inline:
+    let max = clusters_with_data
+        .iter()
+        .map(|cluster| cluster.all.len())
+        .max()
+        .unwrap_or(100);
+    let mut clustered_clusters = vec![vec![]; max + 1];
+    for cluster in clusters_with_data.into_iter() {
+        clustered_clusters[cluster.all.len()].push(cluster);
+    }
+    clustered_clusters
+}
+```
+
+- [ ] **Step 4: Run cargo check to verify compile**
+
+Run: `cargo check -p algorithms`
+Expected: PASS.
+
+- [ ] **Step 5: Verify existing tests + the partition tests still pass**
+
+Run: `cargo test -p algorithms`
+Expected: All passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/algorithms/src/clustering/greedy.rs
+git commit -m "refactor(greedy): extract mode-parameterized candidate generation"
+```
+
+---
+
+## Task 9: `solve_chunk` (per-chunk orchestrator on Greedy)
+
+**Files:**
+- Modify: `server/algorithms/src/clustering/greedy.rs` (add method on `impl<'a> Greedy`)
+- Modify: `server/algorithms/src/clustering/partition.rs` (only if helpers need exposure)
+
+- [ ] **Step 1: Write failing test in partition.rs**
+
+Append to the test module in `partition.rs`:
+
+```rust
+#[test]
+fn ownership_filter_drops_foreign_centers() {
+    use crate::clustering::greedy::Greedy;
+
+    // Two non-adjacent dense clusters; partition should produce >=2 chunks.
+    // Each chunk's solve_chunk result must contain ONLY centers parenting to its cell.
+    let mut pts = dense_cluster([10.0, 20.0], 100, 50.0, 1);
+    pts.extend(dense_cluster([40.0, 80.0], 100, 50.0, 2));
+
+    let mut greedy = Greedy::default();
+    greedy.set_cluster_mode(ClusterMode::Better).set_radius(70.0);
+
+    let chunks = adaptive_partition(&pts, usize::MAX, ClusterMode::Better, 6, 18);
+    assert!(chunks.len() >= 2, "two distant clusters should produce >=2 chunks");
+
+    let tree = crate::rtree::spawn(70.0, &pts);
+    for chunk in &chunks {
+        let (solution, _downgrade) = greedy.solve_chunk(chunk, &tree, usize::MAX);
+        for p in &solution {
+            assert!(
+                contains_latlng(chunk.cell, p.center),
+                "cluster center {:?} must be inside owned cell {:?}",
+                p.center, chunk.cell
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p algorithms --lib clustering::partition::tests::ownership_filter_drops_foreign_centers`
+Expected: FAIL (method `solve_chunk` not found).
+
+- [ ] **Step 3: Implement `solve_chunk` on Greedy**
+
+Add inside `impl<'a> Greedy` in `greedy.rs`, after `associate_clusters_for_chunk`:
+
+```rust
+pub(crate) fn solve_chunk(
+    &'a self,
+    chunk: &crate::clustering::partition::Chunk,
+    all_points_tree: &RTree<Point>,
+    budget: usize,
+) -> (HashSet<Point>, Option<(ClusterMode, ClusterMode)>) {
+    use crate::clustering::partition::{gather_halo, select_effective_mode, contains_latlng};
+
+    let halo = gather_halo(chunk.cell, all_points_tree, self.radius);
+    let combined: SingleVec = chunk
+        .owned
+        .iter()
+        .cloned()
+        .chain(halo.iter().map(|p| p.center))
+        .collect();
+
+    let effective_mode = select_effective_mode(self.cluster_mode, &combined, budget);
+    let downgrade = (effective_mode != self.cluster_mode)
+        .then(|| (self.cluster_mode, effective_mode));
+
+    let point_tree: RTree<Point> = crate::rtree::spawn(self.radius, &combined);
+    let clusters_with_data =
+        self.associate_clusters_for_chunk(&combined, &point_tree, effective_mode, budget);
+
+    let mut solution: Vec<Cluster> = self.cluster(&clusters_with_data).into_iter().collect();
+    self.update_unique(&mut solution);
+
+    solution.retain(|cluster| contains_latlng(chunk.cell, cluster.point.center));
+    let result: HashSet<Point> = solution.into_iter().map(|c| c.into()).collect();
+    (result, downgrade)
+}
+```
+
+The visibility must be `pub(crate)` so the partition module's tests can reach it.
+
+- [ ] **Step 4: Run all algorithm tests to verify pass**
+
+Run: `cargo test -p algorithms`
+Expected: All passing including the new ownership test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/algorithms/src/clustering/greedy.rs server/algorithms/src/clustering/partition.rs
+git commit -m "feat(greedy): solve_chunk with halo + ownership filter + downgrade reporting"
+```
+
+---
+
+## Task 10: `run_partitioned` + wire `Greedy::run` + setter deprecation
+
+**Files:**
+- Modify: `server/algorithms/src/clustering/greedy.rs`
+
+- [ ] **Step 1: Write smoke tests for Greedy::run on Better/Best with huge bbox**
+
+Append to the test module in `partition.rs`:
+
+```rust
+#[test]
+fn greedy_better_completes_huge_random_bbox() {
+    use crate::clustering::greedy::Greedy;
+    let pts = random_points_in_bbox(10_000, [-10., -10., 10., 10.], 42);
+    let mut greedy = Greedy::default();
+    greedy.set_cluster_mode(ClusterMode::Better).set_radius(70.0);
+    let result = greedy.run(&pts);
+    assert!(!result.is_empty(), "Better mode should produce some clusters");
+}
+
+#[test]
+fn greedy_best_completes_huge_random_bbox() {
+    use crate::clustering::greedy::Greedy;
+    let pts = random_points_in_bbox(5_000, [-5., -5., 5., 5.], 42);
+    let mut greedy = Greedy::default();
+    greedy.set_cluster_mode(ClusterMode::Best).set_radius(70.0);
+    let result = greedy.run(&pts);
+    assert!(!result.is_empty(), "Best mode should produce some clusters");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (run_partitioned not yet wired)**
+
+Run: `cargo test -p algorithms --lib clustering::partition::tests::greedy_better_completes_huge_random_bbox`
+Expected: FAIL — `Greedy::run` for Better still calls the old single-shot `setup`. Tests likely time out or panic on these input sizes without the new partitioner. If they happen to pass with a small heap, that's OK — they will still serve as regression guards once `run_partitioned` is in place.
+
+- [ ] **Step 3: Implement `run_partitioned` and wire `run`**
+
+In `greedy.rs`, add inside `impl<'a> Greedy`:
+
+```rust
+fn run_partitioned(&'a self, points: &SingleVec) -> HashSet<Point> {
+    use crate::clustering::partition::{adaptive_partition, PartitionConfig, PartitionStats};
+    use rayon::prelude::*;
+
+    let config = PartitionConfig::load();
+    let all_points_tree: RTree<Point> = crate::rtree::spawn(self.radius, points);
+    let chunks = adaptive_partition(
+        points,
+        config.budget,
+        self.cluster_mode,
+        config.start_level,
+        config.max_level,
+    );
+
+    let mut stats = PartitionStats::default();
+    stats.total_chunks = chunks.len();
+
+    let chunk_results: Vec<(HashSet<Point>, Option<(ClusterMode, ClusterMode)>)> = chunks
+        .par_iter()
+        .map(|chunk| self.solve_chunk(chunk, &all_points_tree, config.budget))
+        .collect();
+
+    let mut solution: HashSet<Point> = HashSet::new();
+    for (chunk_solution, downgrade) in chunk_results {
+        solution.extend(chunk_solution);
+        if let Some(pair) = downgrade {
+            *stats.downgrades.entry(pair).or_insert(0) += 1;
+        }
+    }
+
+    log::info!(
+        "partition: {} chunks, downgrades: {:?}",
+        stats.total_chunks,
+        stats.downgrades,
+    );
+
+    if self.min_points == 1 {
+        // Reuse check_missing's logic. The current check_missing takes Vec<Cluster>;
+        // convert solution to a Vec of Cluster wrappers to call it, OR copy the
+        // missing-point recovery logic inline. We inline since the conversion is awkward.
+        let seen_cell_ids: HashSet<CellID> = solution
+            .iter()
+            .map(|p| p.cell_id)
+            .collect();
+        if seen_cell_ids.len() != points.len() {
+            let missing: Vec<Point> = points
+                .into_par_iter()
+                .filter_map(|p| {
+                    let cell_id = CellID::from(LatLng::from_degrees(p[0], p[1])).parent(20);
+                    if seen_cell_ids.contains(&cell_id) {
+                        None
+                    } else {
+                        Some(Point::new(self.radius, 20, *p))
+                    }
+                })
+                .collect();
+            solution.extend(missing);
+        }
+        log::info!("final solution size: {}", solution.len());
+    }
+    solution
+}
+```
+
+Update `run` (greedy.rs:69-105). Replace its current body with:
+
+```rust
+pub fn run(&'a self, points: &SingleVec) -> SingleVec {
+    let time = Instant::now();
+    log::info!("starting algorithm with {} data points", points.len());
+
+    let return_set = match self.cluster_mode {
+        ClusterMode::Better | ClusterMode::Best => self.run_partitioned(points),
+        _ => self.setup(points),
+    };
+
+    log::info!("finished in {:.2}s", time.elapsed().as_secs_f32());
+    return_set.into_iter().map(|p| p.center).collect()
+}
+```
+
+- [ ] **Step 4: Add deprecation warning to setter**
+
+Replace `set_cluster_split_level` (greedy.rs:64-67) with:
+
+```rust
+pub fn set_cluster_split_level(&mut self, cluster_split_level: u64) -> &mut Self {
+    if cluster_split_level != 0 {
+        log::warn!(
+            "cluster_split_level is deprecated and will be ignored. \
+             Adaptive S2 partitioning is now automatic for Better/Best modes."
+        );
+    }
+    self.cluster_split_level = cluster_split_level;
+    self
+}
+```
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `cargo test -p algorithms`
+Expected: All partition tests + smoke tests pass.
+
+- [ ] **Step 6: Run clippy to catch obvious issues**
+
+Run: `cargo clippy -p algorithms -- -D warnings`
+Expected: No warnings. Fix any inline.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/algorithms/src/clustering/greedy.rs server/algorithms/src/clustering/partition.rs
+git commit -m "feat(greedy): adaptive partition for Better/Best modes + deprecate cluster_split_level"
+```
+
+---
+
+## Task 11: Manual smoke against larger synthetic input + log inspection
+
+**Files:**
+- No file changes; this is a manual verification task.
+
+- [ ] **Step 1: Add an `#[ignore]`-d benchmark-shaped test**
+
+Append to the test module in `partition.rs`:
+
+```rust
+#[test]
+#[ignore]  // run with: cargo test -p algorithms -- --ignored
+fn manual_smoke_huge_bbox_better_mode() {
+    use crate::clustering::greedy::Greedy;
+    use std::time::Instant;
+
+    let pts = random_points_in_bbox(50_000, [-45., -90., 45., 90.], 12345);
+    let mut greedy = Greedy::default();
+    greedy.set_cluster_mode(ClusterMode::Better).set_radius(70.0);
+
+    let t = Instant::now();
+    let result = greedy.run(&pts);
+    let elapsed = t.elapsed();
+
+    eprintln!(
+        "manual_smoke: {} input pts → {} clusters in {:.2}s",
+        pts.len(),
+        result.len(),
+        elapsed.as_secs_f32()
+    );
+    assert!(!result.is_empty());
+}
+```
+
+- [ ] **Step 2: Run with `--ignored` and check log output**
+
+Run:
+```bash
+RUST_LOG=info cargo test -p algorithms --lib clustering::partition::tests::manual_smoke_huge_bbox_better_mode -- --ignored --nocapture
+```
+
+Expected output includes:
+- `PartitionConfig: budget=..., start_level=6, max_level=18`
+- `partition: N chunks, downgrades: {...}` where N > 1
+- Total elapsed under a reasonable bound (no specific assertion; this is for human inspection).
+
+If the run OOMs or hangs, lower the test point count or set `KOJI_MAX_CANDIDATES_PER_CHUNK=100000` before running.
+
+- [ ] **Step 3: Commit the ignored test**
+
+```bash
+git add server/algorithms/src/clustering/partition.rs
+git commit -m "test(partition): add ignored manual smoke for huge bbox"
+```
+
+---
+
+## Final Verification Checklist
+
+- [ ] `cargo test -p algorithms` — all tests pass
+- [ ] `cargo clippy -p algorithms -- -D warnings` — clean
+- [ ] `cargo check --workspace` — no compile errors in dependents
+- [ ] `cargo test -p algorithms -- --ignored --nocapture` — manual smoke passes, partition log shows expected shape
+- [ ] `grep -n "cluster_split_level" server/algorithms/src/clustering/` — no removed-but-not-replaced references
+- [ ] Final review of `git log --oneline main..HEAD` — clean linear history, conventional commits
+
+## Open Risks & Notes for Implementer
+
+1. **`Point` is `Clone + Copy`** — confirmed at `server/algorithms/src/rtree/point.rs:15` (`#[derive(Debug, Clone, Copy)]`). `.cloned()` calls in `gather_halo` are safe.
+
+2. **`rstar` API drift** — `locate_in_envelope_intersecting` is the assumed method on `RTree`. Confirm against rstar 0.12.2 docs in `~/.cargo/registry/src/.../rstar-0.12.2/src/rtree.rs` if the call fails to compile.
+
+3. **`create_cell_map` re-entry** — used in `adaptive_partition` to subdivide. Verify in `server/algorithms/src/s2.rs:353` that the level argument is `u64` and it dedupes points correctly when called recursively. It currently uses `parent(split_level)` which is safe for any level ≤ source level.
+
+4. **Test threading** — rayon par_iter within tests can cause oversubscription. If tests flake, run with `--test-threads=1`.
+
+5. **The `Greedy::cluster` method (greedy.rs:262-388)** is reused unchanged by `solve_chunk`. It already iterates `clusters_with_data` and produces a `HashSet<Cluster>`. No changes needed there.
+
+6. **`Point::cell_id`** — referenced in `run_partitioned`'s missing-point recovery. Confirmed via `check_missing` in greedy.rs:411-415 that `Point` has a `cell_id` field. If it doesn't compile, use `from_array_to_cell_id(p.center, 20)` (s2.rs:344) instead.

--- a/docs/superpowers/specs/2026-05-27-greedy-bbox-adaptive-partition-design.md
+++ b/docs/superpowers/specs/2026-05-27-greedy-bbox-adaptive-partition-design.md
@@ -1,0 +1,456 @@
+# Greedy Clustering — Adaptive S2 Partition (Short-Term Patch)
+
+**Date:** 2026-05-27
+**Status:** Design
+**Scope:** Short-term patch for `ClusterMode::Better` and `ClusterMode::Best` candidate-count explosion on huge bboxes. Long-term algorithm rework is out of scope; this patch is a contained, reversible safety net.
+
+## Problem
+
+When a user selects `Better` or `Best` and the input points are spread across a very large bbox, the greedy algorithm in [`server/algorithms/src/clustering/greedy.rs`](../../../server/algorithms/src/clustering/greedy.rs) generates tens to hundreds of millions of candidate cluster centers:
+
+1. `get_s2_clusters` walks every level-16 S2 cell in the bbox down to level 22, producing up to `4096` leaves per occupied level-16 ancestor.
+2. `Best` mode additionally calls `gen_clusters(BYTE * 6, points)` which produces `(BYTE * 6)² = 37,748,736` jittered grid candidates regardless of bbox size.
+3. The existing `cluster_split_level` setter is documented internally as not recommended (overlaps with rayon parallelism, manual tuning required).
+
+This causes memory pressure, slow runs, and occasionally OOM.
+
+## Non-Goals
+
+- Cluster quality improvement (coverage %, packing efficiency).
+- Replacing the greedy algorithm.
+- Adding committed real-world test datasets.
+- Public API additions (no new caller-facing setters).
+
+## Design
+
+### Section 1 — Architecture Overview
+
+Adaptive partitioner sits between `Greedy::run` and `Greedy::setup` for `Better` and `Best` modes only. All other modes (`Honeycomb`, `Balanced`, `Fast`, `Custom`) keep the existing path.
+
+```
+Greedy::run(points)
+  ├─ if cluster_mode ∈ {Better, Best}:
+  │     ├─ adaptive_partition(points, budget) → Vec<Chunk>
+  │     ├─ par_iter chunks → solve_chunk(chunk) → HashSet<Point>
+  │     ├─ filter centers by cell-of-center ownership (inside solve_chunk)
+  │     └─ union → final SingleVec
+  └─ else: existing path unchanged
+```
+
+The `cluster_split_level` field and setter are retained for source compatibility but the value is ignored. Non-zero values logged as deprecation warning.
+
+A new module `server/algorithms/src/clustering/partition.rs` houses the partitioner, cost estimator, halo gatherer, ownership filter, and fallback ladder.
+
+**Orchestration sketch** (private method on `Greedy`):
+
+```rust
+fn run_partitioned(&self, points: &SingleVec) -> HashSet<Point> {
+    let config = PartitionConfig::load();  // OnceLock-cached env+sysinfo
+    let all_points_tree: RTree<Point> = rtree::spawn(self.radius, points);
+    let chunks = adaptive_partition(
+        points,
+        config.budget,
+        self.cluster_mode,
+        config.start_level,
+        config.max_level,
+    );
+
+    let mut stats = PartitionStats::default();
+    stats.total_chunks = chunks.len();
+
+    let chunk_results: Vec<(HashSet<Point>, Option<(ClusterMode, ClusterMode)>)> = chunks
+        .par_iter()
+        .map(|chunk| self.solve_chunk(chunk, &all_points_tree, config.budget))
+        .collect();
+
+    let mut solution: HashSet<Point> = HashSet::new();
+    for (chunk_solution, downgrade) in chunk_results {
+        solution.extend(chunk_solution);
+        if let Some(pair) = downgrade {
+            *stats.downgrades.entry(pair).or_insert(0) += 1;
+        }
+    }
+
+    log::info!("partition: {} chunks, downgrades: {:?}", stats.total_chunks, stats.downgrades);
+
+    if self.min_points == 1 {
+        // Cluster -> Point conversion already done in solve_chunk via .into();
+        // re-use check_missing semantics (greedy.rs:409) against the original points.
+        self.check_missing_points(solution, points)
+    } else {
+        solution
+    }
+}
+```
+
+`check_missing_points` is a small refactor of the existing `check_missing` (greedy.rs:408-441) to accept a `HashSet<Point>` directly instead of `Vec<Cluster>`. Same logic, different input type.
+
+### Section 2 — Adaptive S2 Partition Algorithm
+
+**Types:**
+
+```rust
+pub(crate) struct Chunk {
+    pub cell: CellID,        // owns clusters whose centers parent to this cell at cell.level()
+    pub owned: SingleVec,    // points whose level-`cell.level()` parent == cell
+}
+
+pub(crate) struct PartitionConfig {
+    pub budget: usize,
+    pub start_level: u64,
+    pub max_level: u64,
+}
+
+#[derive(Default)]
+pub(crate) struct PartitionStats {
+    pub total_chunks: usize,
+    pub downgrades: HashMap<(ClusterMode, ClusterMode), usize>,
+}
+```
+
+Top-down BFS descent. Start at a coarse S2 level, subdivide any cell whose estimated cost exceeds the budget. Halt at `MAX_LEVEL` regardless.
+
+```rust
+fn adaptive_partition(
+    points: &SingleVec,
+    budget: usize,
+    mode: ClusterMode,
+    start_level: u64,
+    max_level: u64,
+) -> Vec<Chunk> {
+    // create_cell_map (server/algorithms/src/s2.rs:353) returns HashMap<u64, SingleVec>
+    // where the key is CellID.0 (the raw u64 id).
+    let mut frontier: HashMap<u64, SingleVec> = create_cell_map(points, start_level);
+    let mut accepted: Vec<Chunk> = vec![];
+
+    loop {
+        let mut next_frontier: HashMap<u64, SingleVec> = HashMap::new();
+        for (cell_id_raw, cell_points) in frontier {
+            let cell = CellID(cell_id_raw);
+            let est = estimate_cost(&cell_points, mode, budget);
+            if est <= budget || cell.level() >= max_level {
+                accepted.push(Chunk { cell, owned: cell_points });
+            } else {
+                let children = create_cell_map(&cell_points, cell.level() + 1);
+                next_frontier.extend(children);
+            }
+        }
+        if next_frontier.is_empty() { break; }
+        frontier = next_frontier;
+    }
+
+    accepted
+}
+```
+
+**Defaults:**
+- `START_LEVEL = 6` — ~165km cells at equator. One chunk for small bbox, partitioned for large.
+- `MAX_LEVEL = 18` — ~80m cells. Below this, cell size approaches cluster radius (70m), further subdivision is degenerate.
+
+Both env-overridable: `KOJI_PARTITION_START_LEVEL`, `KOJI_PARTITION_MAX_LEVEL`.
+
+`gather_halo` (Section 4) is computed lazily inside `solve_chunk` against a shared `Arc<RTree<Point>>` built once over all points before partitioning.
+
+### Section 3 — Cost Estimator
+
+Estimates the actual candidate count a chunk will materialize under the requested mode, **accounting for grid density scaling**. Used by both the partitioner (Section 2) and the fallback ladder (Section 5) so both reason about the same number.
+
+```rust
+const BYTES_PER_CANDIDATE: usize = 256;
+
+fn distinct_l16_cells(points: &[PointArray]) -> usize {
+    points.iter()
+        .map(|p| CellID::from(LatLng::from_degrees(p[0], p[1])).parent(16))
+        .collect::<HashSet<_>>()
+        .len()
+}
+
+fn scaled_grid_density(s2_cost: usize, budget: usize) -> usize {
+    let remaining = budget.saturating_sub(s2_cost);
+    let density = (remaining as f64).sqrt() as usize;
+    density.min(BYTE * 6)
+}
+
+fn estimate_cost(points: &[PointArray], mode: ClusterMode, budget: usize) -> usize {
+    let s2_cost = distinct_l16_cells(points) * 4096;  // 4^(22-16)
+    let grid_cost = if mode == ClusterMode::Best {
+        scaled_grid_density(s2_cost, budget).pow(2)
+    } else {
+        0
+    };
+    s2_cost + grid_cost
+}
+```
+
+**Grid density scaling is applied inside `solve_chunk` for Best mode**:
+
+```rust
+let s2_cost_actual = distinct_l16_cells(&combined) * 4096;
+let grid_density = scaled_grid_density(s2_cost_actual, budget);
+```
+
+If `s2_cost_actual >= budget`, `grid_density = 0` → grid contribution dropped, S2 walk only. This collapses Best to Better effectively without invoking the fallback ladder. The estimator returns the same scaled cost, so the ladder is only invoked when even the S2 walk alone exceeds budget.
+
+**Budget computation:**
+
+```rust
+let sys = System::new_all();
+let mem_per_thread = sys.available_memory() / rayon::current_num_threads() as u64;
+let auto_budget = (mem_per_thread / BYTES_PER_CANDIDATE as u64) as usize;
+let budget = std::env::var("KOJI_MAX_CANDIDATES_PER_CHUNK")
+    .ok()
+    .and_then(|s| s.parse().ok())
+    .unwrap_or(auto_budget);
+```
+
+`BYTES_PER_CANDIDATE = 256` is empirical: `PointArray` (16 bytes) plus the per-cluster `Cluster<Point>` overhead with its associated point Vec.
+
+Config cached in `OnceLock<PartitionConfig>` to avoid repeated env parsing. Effective values logged at first use.
+
+### Section 4 — Halo + Ownership Semantics
+
+A single `RTree<Point>` is built once over all input points before partitioning and shared (via `&RTree<Point>` borrow into the rayon `par_iter`) across all chunks. This avoids per-chunk rtree rebuild and lets each chunk efficiently query its halo region.
+
+**Halo gather:**
+
+```rust
+fn gather_halo(
+    cell: CellID,
+    all_points_tree: &RTree<Point>,
+    radius_meters: f64,
+) -> Vec<Point> {
+    // Cell bbox from S2: Cell::from(&cell).rect_bound() returns an S2 Rect,
+    // which we project to [min_lat, min_lon, max_lat, max_lon].
+    let cell_bbox = cell_bbox_lat_lon(cell);
+    let radius_deg = meters_to_degrees(radius_meters, cell_bbox.center_lat());
+    let expanded = cell_bbox.expand(radius_deg);
+    all_points_tree
+        .locate_in_envelope_intersecting(&expanded.envelope())
+        .filter(|p| !contains_latlng(cell, p.center))
+        .cloned()
+        .collect()
+}
+```
+
+**Helpers introduced by this patch** (live in `partition.rs`):
+
+```rust
+fn cell_bbox_lat_lon(cell: CellID) -> BBox;             // S2 Rect → [min/max lat/lon]
+fn contains_latlng(cell: CellID, p: [f64; 2]) -> bool;  // CellID::from(LatLng).parent(cell.level()) == cell
+```
+
+`contains_latlng` is implemented by re-deriving the cell at the partition level from the lat/lon and comparing to the chunk's owning cell — this is the same deterministic rule used for ownership, so no separate tie-break is required.
+
+**Per-chunk solve:**
+
+```rust
+fn solve_chunk(
+    &self,
+    chunk: &Chunk,
+    all_points_tree: &RTree<Point>,
+    budget: usize,
+) -> (HashSet<Point>, Option<(ClusterMode, ClusterMode)>) {
+    let halo = gather_halo(chunk.cell, all_points_tree, self.radius);
+    let combined: Vec<PointArray> = chunk.owned.iter().cloned()
+        .chain(halo.iter().map(|p| p.center))
+        .collect();
+
+    let effective_mode = select_effective_mode(self.cluster_mode, &combined, budget);
+    let downgrade = (effective_mode != self.cluster_mode)
+        .then(|| (self.cluster_mode, effective_mode));
+
+    let point_tree: RTree<Point> = rtree::spawn(self.radius, &combined);
+    let clusters = self.associate_clusters_for_chunk(
+        &combined,
+        &point_tree,
+        effective_mode,
+        budget,  // for grid density scaling, see Section 3
+    );
+    let mut solution: Vec<Cluster> = self.cluster(&clusters).into_iter().collect();
+    self.update_unique(&mut solution);
+
+    solution.retain(|cluster| contains_latlng(chunk.cell, cluster.point.center));
+    let result: HashSet<Point> = solution.into_iter().map(Into::into).collect();
+    (result, downgrade)
+}
+```
+
+**Critical semantics:**
+- Halo points participate as targets (can be covered) but cluster centers landing in halo (i.e. outside owned cell) are dropped via `retain`.
+- `CellID::from(LatLng).parent(level)` is deterministic — a cluster center is owned by exactly one cell. No tie-break logic needed.
+- Halo radius = cluster `radius` exactly. Sufficient because a cluster center MUST be inside its owned cell; the worst case is a center at the cell edge, which reaches `radius` into the neighbor.
+
+**Halo cost:** for a level-6 cell (~27,225 km² area, ~660 km perimeter) with 70m radius, halo area ≈ 46.2 km² ≈ 0.17% of cell area. Negligible.
+
+**Final merge:** plain `HashSet::extend` across all chunks. Ownership filter guarantees zero center duplicates.
+
+### Section 5 — Stepwise Fallback Ladder
+
+A chunk at `MAX_LEVEL` with `estimate_cost > budget` is irreducible by partitioning. Apply per-chunk mode downgrade:
+
+```rust
+fn select_effective_mode(
+    requested: ClusterMode,
+    points: &[PointArray],
+    budget: usize,
+) -> ClusterMode {
+    let mut current = requested;
+    loop {
+        if estimate_cost(points, current, budget) <= budget || current == ClusterMode::Fast {
+            return current;
+        }
+        let next = match current {
+            ClusterMode::Best => ClusterMode::Better,
+            ClusterMode::Better => ClusterMode::Balanced,
+            ClusterMode::Balanced => ClusterMode::Fast,
+            _ => return current,
+        };
+        log::warn!(
+            "chunk over budget for {:?} (est={}, budget={}), downgrading to {:?}",
+            current,
+            estimate_cost(points, current, budget),
+            budget,
+            next,
+        );
+        current = next;
+    }
+}
+```
+
+**Ladder ordering rationale:**
+- `Best → Better` — drops the grid candidate source entirely. Note: because `estimate_cost` already accounts for grid density scaling (Section 3), this step only triggers when even the S2 walk alone exceeds budget — at which point `Better` is also over budget and the loop continues straight to `Balanced`. Kept in the ladder for log granularity and forward-compat.
+- `Better → Balanced` — drops the S2 cell walk, falls back to a `BYTE = 1024` grid (~1M candidates).
+- `Balanced → Fast` — further reduces grid density to `BYTE / 2 = 512` (~262K candidates).
+- `Fast` is the floor; even pathological chunks complete.
+
+`solve_chunk` is parameterized by `effective_mode`. The existing mode switch in `associate_clusters` (greedy.rs:168-181) is extracted into a new helper `associate_clusters_for_chunk(points, point_tree, effective_mode, budget)` that takes the resolved mode as a parameter rather than reading `self.cluster_mode`. The rest of `associate_clusters`'s body (filter by min_points, memory log, bucket by cluster size) is reused.
+
+**Observability:**
+
+Two layers:
+
+1. **Per-downgrade `log::warn!`** inside `select_effective_mode` — already shown above. Grep-able in logs to count occurrences after the fact.
+2. **Summary `log::info!` per `run` call** — `solve_chunk` returns both the cluster set and an `Option<(ClusterMode, ClusterMode)>` recording the original→effective mode (if any downgrade happened). The orchestrator aggregates these into `PartitionStats` after `par_iter`:
+
+```rust
+let results: Vec<(HashSet<Point>, Option<(ClusterMode, ClusterMode)>)> = chunks
+    .par_iter()
+    .map(|chunk| self.solve_chunk(chunk, &all_points_tree, config.budget))
+    .collect();
+
+for (_, dg) in &results {
+    if let Some(pair) = dg { *stats.downgrades.entry(*pair).or_insert(0) += 1; }
+}
+log::info!("partition: {} chunks, downgrades: {:?}", stats.total_chunks, stats.downgrades);
+```
+
+No metrics-system dependency. Logs only.
+
+### Section 6 — API & Config Changes
+
+**Public API surface impact: zero.** No new setters, no removed setters, no signature changes.
+
+**`Greedy::set_cluster_split_level`** — retained, but body adds:
+
+```rust
+pub fn set_cluster_split_level(&mut self, cluster_split_level: u64) -> &mut Self {
+    if cluster_split_level != 0 {
+        log::warn!(
+            "cluster_split_level is deprecated and will be ignored. \
+             Adaptive S2 partitioning is now automatic for Better/Best modes."
+        );
+    }
+    self.cluster_split_level = cluster_split_level;
+    self
+}
+```
+
+**`Greedy::run`** — branch removed:
+
+```rust
+pub fn run(&'a self, points: &SingleVec) -> SingleVec {
+    let time = Instant::now();
+    log::info!("starting algorithm with {} data points", points.len());
+
+    let return_set = match self.cluster_mode {
+        ClusterMode::Better | ClusterMode::Best => self.run_partitioned(points),
+        _ => self.setup(points),
+    };
+
+    log::info!("finished in {:.2}s", time.elapsed().as_secs_f32());
+    return_set.into_iter().map(|p| p.center).collect()
+}
+```
+
+**Caller site (`server/algorithms/src/clustering/mod.rs:57-66`)** — unchanged. Deprecation warning fires from the setter when a non-zero value is passed.
+
+**Env vars (new, all optional):**
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `KOJI_MAX_CANDIDATES_PER_CHUNK` | auto from `sysinfo` | Override per-chunk budget |
+| `KOJI_PARTITION_START_LEVEL` | `6` | Coarse S2 level to start descent |
+| `KOJI_PARTITION_MAX_LEVEL` | `18` | Halt descent at this depth |
+
+All cached in `OnceLock<PartitionConfig>`. Effective values logged at startup.
+
+### Section 7 — Testing & Verification
+
+**Test helpers** in `server/algorithms/src/clustering/partition.rs#[cfg(test)] mod tests`:
+
+```rust
+fn random_points_in_bbox(n: usize, bbox: [f64; 4], seed: u64) -> SingleVec;
+fn dense_cluster(center: [f64; 2], n: usize, radius_m: f64, seed: u64) -> SingleVec;
+fn sparse_grid(rows: usize, cols: usize, bbox: [f64; 4]) -> SingleVec;
+```
+
+All use `SmallRng::seed_from_u64` for determinism. No data files committed.
+
+**Unit tests:**
+
+1. `partition_small_bbox_single_chunk` — 1000 points in ~1km² bbox → expect 1 chunk at `START_LEVEL`.
+2. `partition_huge_sparse_bbox_subdivides` — `sparse_grid(50, 50, [-45., -90., 45., 90.])` → chunk count > 1, bounded by occupied cells.
+3. `partition_dense_cluster_caps_at_max_level` — `dense_cluster([0., 0.], 50_000, 100., 42)` → at least one chunk reaches `MAX_LEVEL`.
+4. `fallback_ladder_best_to_fast` — synthetic input with budget overridden to 100: assert `select_effective_mode` descends through `Best → Better → Balanced → Fast`, one log per step.
+5. `halo_includes_boundary_points` — 2 adjacent cells, points within `radius` across boundary: assert chunk A's combined set contains chunk B's near-boundary points.
+6. `ownership_filter_drops_foreign_centers` — inject a `Cluster` whose `point.center` parents to a foreign cell at partition level: assert filtered out by `solve_chunk`.
+7. `cost_estimator_loose_bound` — for `random_points_in_bbox(n, bbox)`, assert `estimate_cost ≤ 4× actual_candidate_vec_len` after running `associate_clusters`. Loose sanity check, not strict equality.
+
+**Smoke / shape tests:**
+
+8. `greedy_better_completes_huge_random_bbox` — `random_points_in_bbox(10_000, [-10., -10., 10., 10.], 42)`, `ClusterMode::Better` → completes (no panic), returns non-empty `SingleVec`.
+9. `greedy_best_completes_huge_random_bbox` — same with `Best`.
+
+**Regression:**
+
+10. Existing tests in `server/algorithms/src/clustering/` continue to pass unchanged for normal bbox sizes (where partitioner stays at single chunk at `START_LEVEL`).
+
+**Deliberately skipped:**
+- Real-world dataset tests (per project preference for now).
+- Cluster quality regression (% coverage delta). Out of scope.
+- Perf wall-clock assertions (CI variance too noisy).
+
+## Implementation Order
+
+1. Create `partition.rs` skeleton with `PartitionConfig`, `Chunk` struct, env loader.
+2. Implement `estimate_cost` + `distinct_l16_cells` + unit tests for cost math.
+3. Implement `adaptive_partition` (Section 2) + unit tests for partition shape.
+4. Implement `gather_halo` + `solve_chunk` with ownership filter + unit tests for halo/ownership.
+5. Implement `select_effective_mode` (fallback ladder) + tests.
+6. Wire `run_partitioned` into `Greedy::run` for Better/Best modes.
+7. Add deprecation warning to `set_cluster_split_level`.
+8. Run smoke tests, full existing test suite.
+
+## Open Risks
+
+- `BYTES_PER_CANDIDATE = 256` is empirical and may be wrong by ±2× on real workloads. Env override exists if so.
+- S2 cell bbox at `START_LEVEL = 6` near the poles has weird aspect ratios. For now, accept — Better/Best near the poles is an unusual case.
+- Rayon parallelism within chunks (existing `par_iter` in `associate_clusters` and `cluster`) plus rayon across chunks could over-subscribe threads. Acceptable for short-term; long-term may want a dedicated thread pool or chunk-level scheduling.
+
+## Long-Term Considerations (Out of Scope)
+
+Listed here only as context for the upcoming algorithm rework:
+
+- Replace S2 walk + grid candidate generation with a unified spatial-index-driven candidate stream.
+- Boundary cluster optimality (current halo+ownership is correct but not globally optimal; a center near a boundary may still be sub-optimal vs. one a neighbor cell would have placed).
+- Quality metric / regression harness with synthetic ground-truth.

--- a/server/algorithms/Cargo.toml
+++ b/server/algorithms/Cargo.toml
@@ -18,7 +18,7 @@ hashbrown = "0.16.0"
 log = "0.4.28"
 map_3d = "0.1.5"
 model = { path = "../model" }
-rand = { version = "0.9.2", default-features = false }
+rand = { version = "0.9.2", default-features = false, features = ["small_rng", "std", "std_rng", "thread_rng"] }
 rayon = "1.11.0"
 rstar = "0.12.2"
 s2 = "0.0.13"

--- a/server/algorithms/src/clustering/greedy.rs
+++ b/server/algorithms/src/clustering/greedy.rs
@@ -154,6 +154,79 @@ impl<'a> Greedy {
         candidates::generate_clusters_from_points(points, self.radius, density)
     }
 
+    fn generate_candidates_for_mode(
+        &self,
+        points: &'a SingleVec,
+        point_tree: &'a RTree<Point>,
+        mode: ClusterMode,
+        grid_density_override: Option<usize>,
+    ) -> SingleVec {
+        const BYTE: usize = 1024;
+        match mode {
+            ClusterMode::Honeycomb => self.get_honeycomb_clusters(points),
+            ClusterMode::Fast => self.gen_clusters(BYTE / 2, points),
+            ClusterMode::Balanced => self.gen_clusters(BYTE, points),
+            ClusterMode::Better | ClusterMode::Best => {
+                let mut pcs = self.get_s2_clusters(points, point_tree);
+                if matches!(mode, ClusterMode::Best) {
+                    let density = grid_density_override.unwrap_or(BYTE * 6);
+                    if density > 0 {
+                        pcs.extend_from_slice(&self.gen_clusters(density, points));
+                    }
+                }
+                pcs
+            }
+            _ => vec![],
+        }
+    }
+
+    fn associate_clusters_for_chunk(
+        &'a self,
+        points: &'a SingleVec,
+        point_tree: &'a RTree<Point>,
+        effective_mode: ClusterMode,
+        budget: usize,
+    ) -> Vec<Vec<Cluster<'a>>> {
+        use crate::clustering::partition::{distinct_l16_cells, scaled_grid_density};
+
+        let grid_density = if matches!(effective_mode, ClusterMode::Best) {
+            let s2_cost = distinct_l16_cells(points).saturating_mul(4096);
+            Some(scaled_grid_density(s2_cost, budget))
+        } else {
+            None
+        };
+
+        let raw_candidates = self.generate_candidates_for_mode(
+            points,
+            point_tree,
+            effective_mode,
+            grid_density,
+        );
+
+        let clusters_with_data: Vec<Cluster> = raw_candidates
+            .into_par_iter()
+            .filter_map(|cluster| {
+                let iter = point_tree.locate_all_at_point(&cluster);
+                let mut points = Vec::with_capacity(iter.size_hint().0);
+                points.extend(iter);
+
+                (points.len() >= self.min_points)
+                    .then(|| Cluster::new(Point::new(self.radius, 20, cluster), points, vec![]))
+            })
+            .collect();
+
+        let max = clusters_with_data
+            .iter()
+            .map(|cluster| cluster.all.len())
+            .max()
+            .unwrap_or(100);
+        let mut clustered_clusters = vec![vec![]; max + 1];
+        for cluster in clusters_with_data.into_iter() {
+            clustered_clusters[cluster.all.len()].push(cluster);
+        }
+        clustered_clusters
+    }
+
     fn associate_clusters(
         &'a self,
         points: &'a SingleVec,
@@ -165,30 +238,18 @@ impl<'a> Greedy {
         let sys_mem = sys.available_memory() as usize / BYTE / BYTE;
 
         let time = Instant::now();
-        let clusters_with_data: Vec<Cluster> = match self.cluster_mode {
-            ClusterMode::Honeycomb => self.get_honeycomb_clusters(points),
-            ClusterMode::Fast => self.gen_clusters(BYTE / 2, points),
-            ClusterMode::Balanced => self.gen_clusters(BYTE, points),
-            ClusterMode::Better | ClusterMode::Best => {
-                let mut pcs = self.get_s2_clusters(points, point_tree);
+        let clusters_with_data: Vec<Cluster> = self
+            .generate_candidates_for_mode(points, point_tree, self.cluster_mode.clone(), None)
+            .into_par_iter()
+            .filter_map(|cluster| {
+                let iter = point_tree.locate_all_at_point(&cluster);
+                let mut points = Vec::with_capacity(iter.size_hint().0);
+                points.extend(iter);
 
-                if self.cluster_mode == ClusterMode::Best {
-                    pcs.extend_from_slice(&self.gen_clusters(BYTE * 6, points));
-                }
-                pcs
-            }
-            _ => vec![],
-        }
-        .into_par_iter()
-        .filter_map(|cluster| {
-            let iter = point_tree.locate_all_at_point(&cluster);
-            let mut points = Vec::with_capacity(iter.size_hint().0);
-            points.extend(iter);
-
-            (points.len() >= self.min_points)
-                .then(|| Cluster::new(Point::new(self.radius, 20, cluster), points, vec![]))
-        })
-        .collect();
+                (points.len() >= self.min_points)
+                    .then(|| Cluster::new(Point::new(self.radius, 20, cluster), points, vec![]))
+            })
+            .collect();
 
         log::info!(
             "associated points with {} clusters in {:.2}s",

--- a/server/algorithms/src/clustering/greedy.rs
+++ b/server/algorithms/src/clustering/greedy.rs
@@ -227,6 +227,38 @@ impl<'a> Greedy {
         clustered_clusters
     }
 
+    pub(crate) fn solve_chunk(
+        &'a self,
+        chunk: &crate::clustering::partition::Chunk,
+        all_points_tree: &RTree<Point>,
+        budget: usize,
+    ) -> (HashSet<Point>, Option<(ClusterMode, ClusterMode)>) {
+        use crate::clustering::partition::{gather_halo, select_effective_mode, contains_latlng};
+
+        let halo = gather_halo(chunk.cell, all_points_tree, self.radius);
+        let combined: SingleVec = chunk
+            .owned
+            .iter()
+            .cloned()
+            .chain(halo.iter().map(|p| p.center))
+            .collect();
+
+        let effective_mode = select_effective_mode(self.cluster_mode.clone(), &combined, budget);
+        let downgrade = (effective_mode != self.cluster_mode)
+            .then(|| (self.cluster_mode.clone(), effective_mode.clone()));
+
+        let point_tree: RTree<Point> = crate::rtree::spawn(self.radius, &combined);
+        let clusters_with_data =
+            self.associate_clusters_for_chunk(&combined, &point_tree, effective_mode, budget);
+
+        let mut solution: Vec<Cluster> = self.cluster(&clusters_with_data).into_iter().collect();
+        self.update_unique(&mut solution);
+
+        solution.retain(|cluster| contains_latlng(chunk.cell, cluster.point.center));
+        let result: HashSet<Point> = solution.into_iter().map(|c| c.into()).collect();
+        (result, downgrade)
+    }
+
     fn associate_clusters(
         &'a self,
         points: &'a SingleVec,

--- a/server/algorithms/src/clustering/greedy.rs
+++ b/server/algorithms/src/clustering/greedy.rs
@@ -293,12 +293,9 @@ impl<'a> Greedy {
         use crate::clustering::partition::{gather_halo, select_effective_mode, contains_latlng};
 
         let halo = gather_halo(chunk.cell, all_points_tree, self.radius);
-        let combined: SingleVec = chunk
-            .owned
-            .iter()
-            .cloned()
-            .chain(halo.iter().map(|p| p.center))
-            .collect();
+        let mut combined: SingleVec = Vec::with_capacity(chunk.owned.len() + halo.len());
+        combined.extend(chunk.owned.iter().copied());
+        combined.extend(halo.iter().map(|p| p.center));
 
         let effective_mode = select_effective_mode(self.cluster_mode.clone(), &combined, budget);
         let downgrade = (effective_mode != self.cluster_mode)

--- a/server/algorithms/src/clustering/greedy.rs
+++ b/server/algorithms/src/clustering/greedy.rs
@@ -253,10 +253,10 @@ impl<'a> Greedy {
         effective_mode: ClusterMode,
         budget: usize,
     ) -> Vec<Vec<Cluster<'a>>> {
-        use crate::clustering::partition::{distinct_l16_cells, scaled_grid_density};
+        use crate::clustering::partition::{s2_walk_cost, scaled_grid_density};
 
         let grid_density = if matches!(effective_mode, ClusterMode::Best) {
-            let s2_cost = distinct_l16_cells(points).saturating_mul(4096);
+            let s2_cost = s2_walk_cost(points);
             Some(scaled_grid_density(s2_cost, budget))
         } else {
             None

--- a/server/algorithms/src/clustering/greedy.rs
+++ b/server/algorithms/src/clustering/greedy.rs
@@ -143,8 +143,11 @@ impl<'a> Greedy {
             })
             .collect();
 
-        // Lossless merge + mygod_score-positive gap-fill.
-        let solution_vec = self.merge_redundant_clusters(solution_vec, &all_points_tree);
+        // Post-greedy gap-fill: each new cluster covering > min_points
+        // previously-uncovered points is a strict mygod_score win.
+        // (merge_redundant_clusters was removed from this path: SEC-per-pair
+        // cost dominates wall-clock on non-dense inputs for ≈0.4% mygod gain.
+        // The fn is still defined and available behind future opt-in flags.)
         let solution_vec = self.fill_coverage_gaps(solution_vec, points, &all_points_tree);
 
         let mut final_solution: HashSet<Point> =

--- a/server/algorithms/src/clustering/greedy.rs
+++ b/server/algorithms/src/clustering/greedy.rs
@@ -67,7 +67,6 @@ impl<'a> Greedy {
                  Adaptive S2 partitioning is now automatic for Better/Best modes."
             );
         }
-        let _ = cluster_split_level; // value intentionally discarded; field removed.
         self
     }
 

--- a/server/algorithms/src/clustering/greedy.rs
+++ b/server/algorithms/src/clustering/greedy.rs
@@ -133,8 +133,8 @@ impl<'a> Greedy {
             let seen_cell_ids: HashSet<CellID> = solution.iter().map(|p| p.cell_id).collect();
             let missing = self.recover_missing_points(&seen_cell_ids, points);
             solution.extend(missing);
-            log::info!("final solution size: {}", solution.len());
         }
+        log::info!("final solution size: {}", solution.len());
         solution
     }
 

--- a/server/algorithms/src/clustering/greedy.rs
+++ b/server/algorithms/src/clustering/greedy.rs
@@ -27,7 +27,6 @@ use crate::{
 
 pub struct Greedy {
     cluster_mode: ClusterMode,
-    cluster_split_level: u64,
     max_clusters: usize,
     min_points: usize,
     radius: Precision,
@@ -37,7 +36,6 @@ impl Default for Greedy {
     fn default() -> Self {
         Greedy {
             cluster_mode: ClusterMode::Balanced,
-            cluster_split_level: 0,
             max_clusters: usize::MAX,
             min_points: 1,
             radius: 70.,
@@ -69,7 +67,7 @@ impl<'a> Greedy {
                  Adaptive S2 partitioning is now automatic for Better/Best modes."
             );
         }
-        self.cluster_split_level = cluster_split_level;
+        let _ = cluster_split_level; // value intentionally discarded; field removed.
         self
     }
 

--- a/server/algorithms/src/clustering/greedy.rs
+++ b/server/algorithms/src/clustering/greedy.rs
@@ -1,7 +1,7 @@
 use geojson::{Feature, Geometry};
 use hashbrown::HashSet;
 use macros::time;
-use model::api::{GetBbox, Precision, cluster_mode::ClusterMode, single_vec::SingleVec};
+use model::api::{GetBbox, Precision, cluster_mode::ClusterMode, point_array::PointArray, single_vec::SingleVec};
 
 use ::s2::{cellid::CellID, latlng::LatLng};
 use rayon::{
@@ -136,6 +136,15 @@ impl<'a> Greedy {
         let bucketed = self.bucket_clusters_by_size(flat_clusters);
         let mut consolidated: Vec<Cluster> = self.cluster(&bucketed).into_iter().collect();
         self.update_unique(&mut consolidated);
+
+        // Post-greedy merge + gap-fill. merge: cluster pairs within 2*radius
+        // where SEC of union fits within radius become one cluster (lossless;
+        // saves min_points per merge). fill: previously-uncovered points
+        // become candidate centers; new cluster covering ≥ min_points other
+        // uncovered points is a strict mygod_score win.
+        let consolidated = self.merge_redundant_clusters(consolidated, &all_points_tree);
+        let consolidated = self.fill_coverage_gaps(consolidated, points, &all_points_tree);
+
         let mut solution: HashSet<Point> = consolidated.into_iter().map(|c| c.into()).collect();
 
         if self.min_points == 1 {
@@ -144,6 +153,235 @@ impl<'a> Greedy {
             solution.extend(missing);
         }
         log::info!("final solution size: {}", solution.len());
+        solution
+    }
+
+    /// Post-greedy merge: walk pairs of nearby cluster centers (within 2*radius)
+    /// and replace any pair whose union of covered points fits within `radius` of
+    /// the pair's midpoint with a single cluster at that midpoint. Lossless —
+    /// coverage is preserved by construction.
+    ///
+    /// The mygod_score formula (`clusters * min_points + uncovered_points`, source
+    /// of truth: stats.rs::Stats::get_score) drops by exactly `min_points` per
+    /// successful merge: one fewer cluster, zero new uncovered points.
+    ///
+    /// Greedy avoidance: each cluster is considered exactly once in index order.
+    /// When two clusters merge they're both marked removed; later iterations skip
+    /// them. A single pass per `run`; cheap (~O(n*k) where k is average neighbor
+    /// count, typically 1-3 for non-degenerate point distributions).
+    fn merge_redundant_clusters(
+        &self,
+        mut solution: Vec<Cluster<'a>>,
+        all_points_tree: &'a RTree<Point>,
+    ) -> Vec<Cluster<'a>> {
+        use ::s2::cellid::CellID;
+        use rstar::AABB;
+
+        if solution.len() < 2 {
+            return solution;
+        }
+
+        // Tree over cluster centers (radius=2*self.radius so envelope queries find
+        // any cluster center within 2r of the query point — the only candidates
+        // geometrically able to merge).
+        let centers: SingleVec = solution.iter().map(|c| c.point.center).collect();
+        let center_tree: RTree<Point> = crate::rtree::spawn(self.radius * 2.0, &centers);
+
+        let id_to_idx: hashbrown::HashMap<CellID, usize> = solution
+            .iter()
+            .enumerate()
+            .map(|(i, c)| (c.point.cell_id, i))
+            .collect();
+
+        let mut removed: HashSet<CellID> = HashSet::with_capacity(solution.len() / 8);
+        let mut additions: Vec<Cluster<'a>> = Vec::new();
+        let mut attempted_merges: usize = 0;
+        let mut successful_merges: usize = 0;
+
+        for i in 0..solution.len() {
+            let cluster = &solution[i];
+            if removed.contains(&cluster.point.cell_id) {
+                continue;
+            }
+
+            // Find candidate neighbors: cluster centers within 2*radius envelope.
+            // Filter out self + already-removed.
+            let neighbors: Vec<&Point> = center_tree
+                .locate_in_envelope_intersecting(&AABB::from_point(cluster.point.center))
+                .filter(|p| {
+                    p.cell_id != cluster.point.cell_id && !removed.contains(&p.cell_id)
+                })
+                .collect();
+
+            for neighbor in neighbors {
+                attempted_merges += 1;
+                let nb_idx = match id_to_idx.get(&neighbor.cell_id) {
+                    Some(idx) => *idx,
+                    None => continue,
+                };
+                let nb_cluster = &solution[nb_idx];
+
+                // Compute SEC of the union of points (de-duped). multi_attempt
+                // returns Centered iff the SEC radius is within self.radius,
+                // i.e. the merge is geometrically possible without coverage loss.
+                let union_points: Vec<&Point> = cluster
+                    .all
+                    .iter()
+                    .chain(nb_cluster.all.iter())
+                    .copied()
+                    .collect();
+                let mut union_dedup: Vec<&Point> = union_points;
+                union_dedup.sort_dedupe();
+
+                let sec_result = crate::sec::sec::multi_attempt(
+                    union_dedup
+                        .iter()
+                        .map(|p| geo::Point::new(p.center[1], p.center[0])),
+                    self.radius,
+                    16,
+                );
+                let merge_center: PointArray = match sec_result {
+                    crate::sec::sec::SmallestEnclosingCircle::Centered(g) => {
+                        [g.y(), g.x()]
+                    }
+                    _ => continue, // SEC won't fit — lossy merges hurt mygod_score
+                };
+
+                // Verify against rtree (planar vs geodesic distance differ).
+                let mid_coverage: HashSet<CellID> = all_points_tree
+                    .locate_all_at_point(&merge_center)
+                    .map(|p| p.cell_id)
+                    .collect();
+                let union_ids: HashSet<CellID> =
+                    union_dedup.iter().map(|p| p.cell_id).collect();
+                if !union_ids.is_subset(&mid_coverage) {
+                    continue;
+                }
+
+                // Build merged cluster.
+                let new_pt = Point::new(self.radius, 20, merge_center);
+                let mut new_all: Vec<&Point> = all_points_tree
+                    .locate_all_at_point(&merge_center)
+                    .collect();
+                new_all.sort_dedupe();
+                additions.push(Cluster::new(new_pt, new_all, vec![]));
+
+                removed.insert(cluster.point.cell_id);
+                removed.insert(nb_cluster.point.cell_id);
+                successful_merges += 1;
+                break;
+            }
+        }
+
+        log::info!(
+            "merge_pass: {} attempts, {} successful merges, -{} clusters",
+            attempted_merges, successful_merges, successful_merges,
+        );
+
+        // Rebuild final solution: kept clusters + new merged clusters.
+        solution.retain(|c| !removed.contains(&c.point.cell_id));
+        solution.extend(additions);
+
+        // Recompute `unique` for the merged solution so downstream callers see
+        // correct uniqueness counts.
+        self.update_unique(&mut solution);
+        solution
+    }
+
+    /// Add clusters centered on previously-uncovered points when a single cluster
+    /// at that point would cover MORE than `min_points` other uncovered points.
+    ///
+    /// mygod_score math: adding a cluster covering `k` previously-uncovered
+    /// points changes (clusters * min_points + uncovered) by
+    ///   +min_points (one more cluster) - k (covered points removed from uncovered)
+    /// Net negative iff k > min_points. We use strict `>` so we only add when
+    /// it's a clear win; `=` would be neutral.
+    ///
+    /// Processes uncovered points in arbitrary order (rayon par_iter is unsafe
+    /// here because each addition affects later points' "still uncovered" set);
+    /// future work could sort by local density to maximize coverage per cluster.
+    fn fill_coverage_gaps(
+        &self,
+        mut solution: Vec<Cluster<'a>>,
+        all_points: &SingleVec,
+        all_points_tree: &'a RTree<Point>,
+    ) -> Vec<Cluster<'a>> {
+        if all_points.is_empty() || self.min_points == 0 {
+            return solution;
+        }
+
+        // Build a tree of current cluster centers so we can ask "is point p
+        // already covered?" (within radius of some cluster center).
+        let center_coords: SingleVec =
+            solution.iter().map(|c| c.point.center).collect();
+        let center_tree: RTree<Point> = crate::rtree::spawn(self.radius, &center_coords);
+
+        // Initial set of uncovered point cell_ids (level 20, dedupes nearby
+        // duplicates the way the rest of the algorithm does).
+        let mut still_uncovered: HashSet<::s2::cellid::CellID> = all_points
+            .iter()
+            .filter_map(|p| {
+                if center_tree.locate_at_point(p).is_some() {
+                    None
+                } else {
+                    let cell_id = ::s2::cellid::CellID::from(
+                        ::s2::latlng::LatLng::from_degrees(p[0], p[1]),
+                    )
+                    .parent(20);
+                    Some(cell_id)
+                }
+            })
+            .collect();
+
+        if still_uncovered.is_empty() {
+            return solution;
+        }
+
+        let initial_uncovered = still_uncovered.len();
+        let mut additions: Vec<Cluster<'a>> = Vec::new();
+
+        // Iterate input order; for each point still uncovered, try as candidate.
+        // Sort-by-local-density would do better but adds O(n log n) over each
+        // uncovered point; this single-pass version is the cheap baseline.
+        for p in all_points {
+            let cell_id = ::s2::cellid::CellID::from(
+                ::s2::latlng::LatLng::from_degrees(p[0], p[1]),
+            )
+            .parent(20);
+            if !still_uncovered.contains(&cell_id) {
+                continue;
+            }
+
+            // Find points within self.radius of `p` that are STILL uncovered.
+            let candidates: Vec<&Point> = all_points_tree
+                .locate_all_at_point(p)
+                .filter(|q| still_uncovered.contains(&q.cell_id))
+                .collect();
+
+            if candidates.len() > self.min_points {
+                // Strict mygod_score win. Place cluster, mark covered.
+                let new_pt = Point::new(self.radius, 20, *p);
+                let mut all_vec: Vec<&Point> = candidates;
+                all_vec.sort_dedupe();
+                for q in &all_vec {
+                    still_uncovered.remove(&q.cell_id);
+                }
+                additions.push(Cluster::new(new_pt, all_vec, vec![]));
+            }
+        }
+
+        log::info!(
+            "fill_coverage_gaps: {} uncovered -> +{} new clusters ({} still uncovered)",
+            initial_uncovered,
+            additions.len(),
+            still_uncovered.len(),
+        );
+
+        solution.extend(additions);
+        // No update_unique here; callers will run check_missing / final conversion.
+        // The added clusters' unique = all (no overlap with existing since they
+        // covered uncovered points by construction); other clusters' unique is
+        // unchanged for the same reason.
         solution
     }
 
@@ -369,9 +607,15 @@ impl<'a> Greedy {
 
         let clusters_with_data = self.associate_clusters(points, &point_tree);
 
-        let mut solution = self.cluster(&clusters_with_data).into_iter().collect();
-
+        let mut solution: Vec<Cluster> = self.cluster(&clusters_with_data).into_iter().collect();
         self.update_unique(&mut solution);
+
+        // Post-greedy gap-fill pass: greedy stops when no candidate covers
+        // min_points unique points. Many points remain uncovered. Adding a new
+        // cluster centered on an uncovered point that covers ≥ min_points OTHER
+        // uncovered points is a strict mygod_score win (covers ≥ min_points+1,
+        // costs min_points -> net negative). See fill_coverage_gaps for math.
+        let solution = self.fill_coverage_gaps(solution, points, &point_tree);
 
         if self.min_points == 1 {
             self.check_missing(solution, points)

--- a/server/algorithms/src/clustering/greedy.rs
+++ b/server/algorithms/src/clustering/greedy.rs
@@ -62,6 +62,12 @@ impl<'a> Greedy {
         self
     }
     pub fn set_cluster_split_level(&mut self, cluster_split_level: u64) -> &mut Self {
+        if cluster_split_level != 0 {
+            log::warn!(
+                "cluster_split_level is deprecated and will be ignored. \
+                 Adaptive S2 partitioning is now automatic for Better/Best modes."
+            );
+        }
         self.cluster_split_level = cluster_split_level;
         self
     }
@@ -70,38 +76,74 @@ impl<'a> Greedy {
         let time = Instant::now();
         log::info!("starting algorithm with {} data points", points.len());
 
-        let return_set = if self.cluster_split_level == 0 {
-            self.setup(points)
-        } else {
-            let cell_maps = s2::create_cell_map(&points, self.cluster_split_level);
-
-            let mut return_set = HashSet::new();
-            std::thread::scope(|s| {
-                let handlers: Vec<std::thread::ScopedJoinHandle<'_, HashSet<Point>>> = cell_maps
-                    .iter()
-                    .map(|(key, values)| {
-                        log::debug!("Cell: {} | Points: {}", key, values.len());
-                        s.spawn(move || self.setup(values))
-                    })
-                    .collect();
-                log::info!("created {} threads", handlers.len());
-                for thread in handlers {
-                    match thread.join() {
-                        Ok(results) => {
-                            return_set.extend(results);
-                        }
-                        Err(e) => {
-                            log::error!("error joining thread: {:?}", e)
-                        }
-                    }
-                }
-            });
-
-            return_set
+        let return_set = match self.cluster_mode {
+            ClusterMode::Better | ClusterMode::Best => self.run_partitioned(points),
+            _ => self.setup(points),
         };
 
         log::info!("finished in {:.2}s", time.elapsed().as_secs_f32());
         return_set.into_iter().map(|p| p.center).collect()
+    }
+
+    fn run_partitioned(&'a self, points: &SingleVec) -> HashSet<Point> {
+        use crate::clustering::partition::{adaptive_partition, PartitionConfig, PartitionStats};
+        use rayon::prelude::*;
+
+        let config = PartitionConfig::load();
+        let all_points_tree: RTree<Point> = crate::rtree::spawn(self.radius, points);
+        let chunks = adaptive_partition(
+            points,
+            config.budget,
+            self.cluster_mode.clone(),
+            config.start_level,
+            config.max_level,
+        );
+
+        let mut stats = PartitionStats::default();
+        stats.total_chunks = chunks.len();
+
+        let chunk_results: Vec<(HashSet<Point>, Option<(ClusterMode, ClusterMode)>)> = chunks
+            .par_iter()
+            .map(|chunk| self.solve_chunk(chunk, &all_points_tree, config.budget))
+            .collect();
+
+        let mut solution: HashSet<Point> = HashSet::new();
+        for (chunk_solution, downgrade) in chunk_results {
+            solution.extend(chunk_solution);
+            if let Some((from, to)) = downgrade {
+                let key = (format!("{:?}", from), format!("{:?}", to));
+                *stats.downgrades.entry(key).or_insert(0) += 1;
+            }
+        }
+
+        log::info!(
+            "partition: {} chunks, downgrades: {:?}",
+            stats.total_chunks,
+            stats.downgrades,
+        );
+
+        if self.min_points == 1 {
+            let seen_cell_ids: HashSet<CellID> = solution
+                .iter()
+                .map(|p| p.cell_id)
+                .collect();
+            if seen_cell_ids.len() != points.len() {
+                let missing: Vec<Point> = points
+                    .into_par_iter()
+                    .filter_map(|p| {
+                        let cell_id = CellID::from(LatLng::from_degrees(p[0], p[1])).parent(20);
+                        if seen_cell_ids.contains(&cell_id) {
+                            None
+                        } else {
+                            Some(Point::new(self.radius, 20, *p))
+                        }
+                    })
+                    .collect();
+                solution.extend(missing);
+            }
+            log::info!("final solution size: {}", solution.len());
+        }
+        solution
     }
 
     fn get_honeycomb_clusters(&self, points: &SingleVec) -> SingleVec {

--- a/server/algorithms/src/clustering/greedy.rs
+++ b/server/algorithms/src/clustering/greedy.rs
@@ -30,6 +30,10 @@ pub struct Greedy {
     max_clusters: usize,
     min_points: usize,
     radius: Precision,
+    /// Dev-only A/B toggle: when `true`, `run()` skips the adaptive S2 partition
+    /// and the post-greedy gap-fill pass, falling back to the pre-PR `setup()`
+    /// path for every mode. See [DevArgs] on the API side.
+    bypass_adaptive_partition: bool,
 }
 
 impl Default for Greedy {
@@ -39,6 +43,7 @@ impl Default for Greedy {
             max_clusters: usize::MAX,
             min_points: 1,
             radius: 70.,
+            bypass_adaptive_partition: false,
         }
     }
 }
@@ -69,14 +74,31 @@ impl<'a> Greedy {
         }
         self
     }
+    /// Dev-only A/B toggle. When `true`, [`Greedy::run`] uses the pre-PR
+    /// `setup()` path for every mode (no adaptive partition, no gap-fill).
+    /// Wired from `DevArgs::bypass_adaptive_partition` via `clustering::main`.
+    pub fn set_bypass_adaptive_partition(&mut self, bypass: bool) -> &mut Self {
+        self.bypass_adaptive_partition = bypass;
+        self
+    }
 
     pub fn run(&'a self, points: &SingleVec) -> SingleVec {
         let time = Instant::now();
         log::info!("starting algorithm with {} data points", points.len());
 
-        let return_set = match self.cluster_mode {
-            ClusterMode::Better | ClusterMode::Best => self.run_partitioned(points),
-            _ => self.setup(points),
+        // Dev A/B toggle: when `bypass_adaptive_partition` is on, every mode
+        // (including Better/Best) goes through the pre-PR `setup()` path with
+        // no partition and no gap-fill — i.e. exactly the algorithm shape from
+        // commit prior to docs/superpowers/specs/2026-05-27-greedy-bbox-adaptive-partition-design.md.
+        // Used for side-by-side quality comparison during PR review.
+        let return_set = if self.bypass_adaptive_partition {
+            log::info!("dev: bypass_adaptive_partition=true (pre-PR algorithm path)");
+            self.setup(points)
+        } else {
+            match self.cluster_mode {
+                ClusterMode::Better | ClusterMode::Best => self.run_partitioned(points),
+                _ => self.setup(points),
+            }
         };
 
         log::info!("finished in {:.2}s", time.elapsed().as_secs_f32());
@@ -241,6 +263,7 @@ impl<'a> Greedy {
     /// When two clusters merge they're both marked removed; later iterations skip
     /// them. A single pass per `run`; cheap (~O(n*k) where k is average neighbor
     /// count, typically 1-3 for non-degenerate point distributions).
+    #[allow(dead_code)] // kept for future opt-in once SEC pre-filter is cheaper
     fn merge_redundant_clusters(
         &self,
         mut solution: Vec<Cluster<'a>>,
@@ -637,7 +660,13 @@ impl<'a> Greedy {
         // cluster centered on an uncovered point that covers ≥ min_points OTHER
         // uncovered points is a strict mygod_score win (covers ≥ min_points+1,
         // costs min_points -> net negative). See fill_coverage_gaps for math.
-        let solution = self.fill_coverage_gaps(solution, points, &point_tree);
+        // Skipped when bypass_adaptive_partition is on so the dev path is
+        // exactly the pre-PR algorithm (no gap-fill).
+        let solution = if self.bypass_adaptive_partition {
+            solution
+        } else {
+            self.fill_coverage_gaps(solution, points, &point_tree)
+        };
 
         if self.min_points == 1 {
             self.check_missing(solution, points)

--- a/server/algorithms/src/clustering/greedy.rs
+++ b/server/algorithms/src/clustering/greedy.rs
@@ -89,11 +89,8 @@ impl<'a> Greedy {
         use rayon::prelude::*;
 
         let config = PartitionConfig::load();
-        // Global rtree built once. All chunk candidate-coverage queries hit this
-        // tree, so a cluster's covered-point count is always computed against the
-        // full input — no per-chunk locality bias. Each chunk still builds its
-        // own small rtree solely to bound the S2 candidate walk (chunk_tree is
-        // dropped before the cluster is added to the global pool).
+        // Global rtree built once for halo gathering and gap-fill. Per-chunk
+        // candidate generation + greedy uses chunk-local data (bounded memory).
         let all_points_tree: RTree<Point> = crate::rtree::spawn(self.radius, points);
         let chunks = adaptive_partition(
             points,
@@ -104,56 +101,128 @@ impl<'a> Greedy {
         );
 
         let mut stats = PartitionStats::default();
-        let mut downgrade_pairs: Vec<(ClusterMode, ClusterMode)> = Vec::new();
 
-        // Per chunk: generate raw candidate cluster centers (S2 walk and/or grid)
-        // bounded by chunk extent + halo for memory, then filter against the
-        // GLOBAL point tree so each Cluster<'a> carries its true global coverage.
-        // Result is a single flat Vec<Cluster<'a>> over the full input.
-        let (all_clusters, chunk_downgrades): (Vec<Vec<Cluster<'_>>>, Vec<Option<(ClusterMode, ClusterMode)>>) = chunks
+        // Per-chunk greedy: each chunk builds its own (owned + halo) rtree,
+        // generates candidates bounded to chunk extent, runs greedy + update_unique
+        // locally, then drops the chunk-local rtree. Memory peak per chunk is
+        // bounded by the budget; flat global Vec<Cluster> never holds all
+        // candidates simultaneously.
+        let chunk_results: Vec<(HashSet<Point>, Option<(ClusterMode, ClusterMode)>)> = chunks
             .par_iter()
-            .map(|chunk| self.generate_chunk_clusters(chunk, &all_points_tree, config.budget))
-            .unzip();
-        let flat_clusters: Vec<Cluster<'_>> = all_clusters.into_iter().flatten().collect();
-        for dg in chunk_downgrades.into_iter().flatten() {
-            downgrade_pairs.push(dg);
-        }
-        for (from, to) in &downgrade_pairs {
-            let key = (mode_tag(from), mode_tag(to));
-            *stats.downgrades.entry(key).or_insert(0) += 1;
+            .map(|chunk| self.solve_chunk_local(chunk, &all_points_tree, config.budget))
+            .collect();
+
+        let mut solution: HashSet<Point> = HashSet::with_capacity(chunks.len() * 32);
+        for (chunk_solution, downgrade) in chunk_results {
+            solution.extend(chunk_solution);
+            if let Some((from, to)) = downgrade {
+                let key = (mode_tag(&from), mode_tag(&to));
+                *stats.downgrades.entry(key).or_insert(0) += 1;
+            }
         }
 
         log::info!(
-            "partition: {} chunks, downgrades: {:?}, total candidate clusters: {}",
+            "partition: {} chunks, downgrades: {:?}, post-chunk centers: {}",
             chunks.len(),
             stats.downgrades,
-            flat_clusters.len(),
+            solution.len(),
         );
 
-        // Single global greedy on the full candidate pool. No chunk-level greedy
-        // means no chunk-boundary quality loss: the greedy sees every cluster's
-        // global coverage and picks the optimal subset directly.
-        let bucketed = self.bucket_clusters_by_size(flat_clusters);
-        let mut consolidated: Vec<Cluster> = self.cluster(&bucketed).into_iter().collect();
-        self.update_unique(&mut consolidated);
+        // Convert HashSet<Point> back to Vec<Cluster> for the merge + gap-fill
+        // passes. Each Cluster's `all` is recomputed against the GLOBAL tree so
+        // these passes see correct coverage counts even though earlier greedy
+        // ran chunk-locally.
+        let solution_vec: Vec<Cluster<'_>> = solution
+            .into_iter()
+            .filter_map(|p| {
+                let mut covered: Vec<&Point> = all_points_tree
+                    .locate_all_at_point(&p.center)
+                    .collect();
+                covered.sort_dedupe();
+                (!covered.is_empty()).then(|| Cluster::new(p, covered, vec![]))
+            })
+            .collect();
 
-        // Post-greedy merge + gap-fill. merge: cluster pairs within 2*radius
-        // where SEC of union fits within radius become one cluster (lossless;
-        // saves min_points per merge). fill: previously-uncovered points
-        // become candidate centers; new cluster covering ≥ min_points other
-        // uncovered points is a strict mygod_score win.
-        let consolidated = self.merge_redundant_clusters(consolidated, &all_points_tree);
-        let consolidated = self.fill_coverage_gaps(consolidated, points, &all_points_tree);
+        // Lossless merge + mygod_score-positive gap-fill.
+        let solution_vec = self.merge_redundant_clusters(solution_vec, &all_points_tree);
+        let solution_vec = self.fill_coverage_gaps(solution_vec, points, &all_points_tree);
 
-        let mut solution: HashSet<Point> = consolidated.into_iter().map(|c| c.into()).collect();
+        let mut final_solution: HashSet<Point> =
+            solution_vec.into_iter().map(|c| c.into()).collect();
 
         if self.min_points == 1 {
-            let seen_cell_ids: HashSet<CellID> = solution.iter().map(|p| p.cell_id).collect();
+            let seen_cell_ids: HashSet<CellID> =
+                final_solution.iter().map(|p| p.cell_id).collect();
             let missing = self.recover_missing_points(&seen_cell_ids, points);
-            solution.extend(missing);
+            final_solution.extend(missing);
         }
-        log::info!("final solution size: {}", solution.len());
-        solution
+        log::info!("final solution size: {}", final_solution.len());
+        final_solution
+    }
+
+    /// Solve a single partition chunk locally and return its cluster centers.
+    /// Greedy runs chunk-locally to bound memory: only the chunk's owned + halo
+    /// points + candidates ever live in memory at once. Result is the set of
+    /// cluster centers owned by this chunk (ownership = cell-of-center).
+    fn solve_chunk_local(
+        &'a self,
+        chunk: &crate::clustering::partition::Chunk,
+        all_points_tree: &'a RTree<Point>,
+        budget: usize,
+    ) -> (HashSet<Point>, Option<(ClusterMode, ClusterMode)>) {
+        use crate::clustering::partition::{
+            contains_latlng, gather_halo, s2_walk_cost, scaled_grid_density,
+            select_effective_mode,
+        };
+
+        let halo = gather_halo(chunk.cell, all_points_tree, self.radius);
+        let mut combined: SingleVec = Vec::with_capacity(chunk.owned.len() + halo.len());
+        combined.extend(chunk.owned.iter().copied());
+        combined.extend(halo.iter().map(|p| p.center));
+
+        let effective_mode = select_effective_mode(self.cluster_mode.clone(), &combined, budget);
+        let downgrade = (effective_mode != self.cluster_mode)
+            .then(|| (self.cluster_mode.clone(), effective_mode.clone()));
+
+        let grid_density = if matches!(effective_mode, ClusterMode::Best) {
+            let s2_cost = s2_walk_cost(&combined);
+            Some(scaled_grid_density(s2_cost, budget))
+        } else {
+            None
+        };
+
+        // chunk_tree scoped so it drops before this fn returns — its memory is
+        // released before the next chunk runs on the same thread.
+        let chunk_tree: RTree<Point> = crate::rtree::spawn(self.radius, &combined);
+        let raw_candidates = self.generate_candidates_for_mode(
+            &combined,
+            &chunk_tree,
+            effective_mode,
+            grid_density,
+        );
+
+        let clusters_with_data: Vec<Cluster> = raw_candidates
+            .into_par_iter()
+            .filter_map(|center| {
+                let iter = chunk_tree.locate_all_at_point(&center);
+                let mut covered = Vec::with_capacity(iter.size_hint().0);
+                covered.extend(iter);
+                (covered.len() >= self.min_points).then(|| {
+                    Cluster::new(Point::new(self.radius, 20, center), covered, vec![])
+                })
+            })
+            .collect();
+
+        let bucketed = self.bucket_clusters_by_size(clusters_with_data);
+        let mut solution: Vec<Cluster> = self.cluster(&bucketed).into_iter().collect();
+        self.update_unique(&mut solution);
+
+        // Ownership filter: a chunk only emits cluster centers whose location
+        // parents to this chunk's owning cell. Adjacent chunks emit their own;
+        // the global merge + gap-fill passes downstream stitch the boundaries.
+        solution.retain(|c| contains_latlng(chunk.cell, c.point.center));
+        let result: HashSet<Point> = solution.into_iter().map(|c| c.into()).collect();
+        (result, downgrade)
     }
 
     /// Post-greedy merge: walk pairs of nearby cluster centers (within 2*radius)
@@ -383,56 +452,6 @@ impl<'a> Greedy {
         // covered uncovered points by construction); other clusters' unique is
         // unchanged for the same reason.
         solution
-    }
-
-    /// Generate raw candidate clusters for one partition chunk, filtered against
-    /// the GLOBAL point tree so coverage counts reflect the entire input set.
-    /// Returns `(clusters, optional_downgrade)`. The chunk-local rtree built to
-    /// bound the S2 walk is dropped before this function returns; the returned
-    /// `Cluster<'a>`s reference only `all_points_tree`.
-    fn generate_chunk_clusters(
-        &'a self,
-        chunk: &crate::clustering::partition::Chunk,
-        all_points_tree: &'a RTree<Point>,
-        budget: usize,
-    ) -> (Vec<Cluster<'a>>, Option<(ClusterMode, ClusterMode)>) {
-        use crate::clustering::partition::{gather_halo, s2_walk_cost, scaled_grid_density, select_effective_mode};
-
-        let halo = gather_halo(chunk.cell, all_points_tree, self.radius);
-        let mut combined: SingleVec = Vec::with_capacity(chunk.owned.len() + halo.len());
-        combined.extend(chunk.owned.iter().copied());
-        combined.extend(halo.iter().map(|p| p.center));
-
-        let effective_mode = select_effective_mode(self.cluster_mode.clone(), &combined, budget);
-        let downgrade = (effective_mode != self.cluster_mode)
-            .then(|| (self.cluster_mode.clone(), effective_mode.clone()));
-
-        let grid_density = if matches!(effective_mode, ClusterMode::Best) {
-            let s2_cost = s2_walk_cost(&combined);
-            Some(scaled_grid_density(s2_cost, budget))
-        } else {
-            None
-        };
-
-        // chunk_tree exists only to bound the S2 walk's flat_map_cells descent.
-        // Drop it after generate_candidates_for_mode by scoping it tightly.
-        let raw_candidates: SingleVec = {
-            let chunk_tree: RTree<Point> = crate::rtree::spawn(self.radius, &combined);
-            self.generate_candidates_for_mode(&combined, &chunk_tree, effective_mode, grid_density)
-        };
-
-        let clusters: Vec<Cluster<'a>> = raw_candidates
-            .into_par_iter()
-            .filter_map(|center| {
-                let iter = all_points_tree.locate_all_at_point(&center);
-                let mut covered = Vec::with_capacity(iter.size_hint().0);
-                covered.extend(iter);
-                (covered.len() >= self.min_points)
-                    .then(|| Cluster::new(Point::new(self.radius, 20, center), covered, vec![]))
-            })
-            .collect();
-
-        (clusters, downgrade)
     }
 
     fn recover_missing_points(

--- a/server/algorithms/src/clustering/greedy.rs
+++ b/server/algorithms/src/clustering/greedy.rs
@@ -89,12 +89,11 @@ impl<'a> Greedy {
         use rayon::prelude::*;
 
         let config = PartitionConfig::load();
-        // Global rtree shared (read-only) across all chunks for halo gathering.
-        // Each chunk's solve_chunk also builds a chunk-local rtree because cluster() and
-        // update_unique() take &'a RTree<Point> bound to chunk-scoped (owned + halo) points.
-        // This means peak rtree memory is roughly 2x points; acceptable for the bounded
-        // candidate budget per chunk. Long-term refactor could fold these into one tree
-        // with cell-level indexing.
+        // Global rtree built once. All chunk candidate-coverage queries hit this
+        // tree, so a cluster's covered-point count is always computed against the
+        // full input — no per-chunk locality bias. Each chunk still builds its
+        // own small rtree solely to bound the S2 candidate walk (chunk_tree is
+        // dropped before the cluster is added to the global pool).
         let all_points_tree: RTree<Point> = crate::rtree::spawn(self.radius, points);
         let chunks = adaptive_partition(
             points,
@@ -105,26 +104,39 @@ impl<'a> Greedy {
         );
 
         let mut stats = PartitionStats::default();
+        let mut downgrade_pairs: Vec<(ClusterMode, ClusterMode)> = Vec::new();
 
-        let chunk_results: Vec<(HashSet<Point>, Option<(ClusterMode, ClusterMode)>)> = chunks
+        // Per chunk: generate raw candidate cluster centers (S2 walk and/or grid)
+        // bounded by chunk extent + halo for memory, then filter against the
+        // GLOBAL point tree so each Cluster<'a> carries its true global coverage.
+        // Result is a single flat Vec<Cluster<'a>> over the full input.
+        let (all_clusters, chunk_downgrades): (Vec<Vec<Cluster<'_>>>, Vec<Option<(ClusterMode, ClusterMode)>>) = chunks
             .par_iter()
-            .map(|chunk| self.solve_chunk(chunk, &all_points_tree, config.budget))
-            .collect();
-
-        let mut solution: HashSet<Point> = HashSet::with_capacity(chunks.len() * 32);
-        for (chunk_solution, downgrade) in chunk_results {
-            solution.extend(chunk_solution);
-            if let Some((from, to)) = downgrade {
-                let key = (mode_tag(&from), mode_tag(&to));
-                *stats.downgrades.entry(key).or_insert(0) += 1;
-            }
+            .map(|chunk| self.generate_chunk_clusters(chunk, &all_points_tree, config.budget))
+            .unzip();
+        let flat_clusters: Vec<Cluster<'_>> = all_clusters.into_iter().flatten().collect();
+        for dg in chunk_downgrades.into_iter().flatten() {
+            downgrade_pairs.push(dg);
+        }
+        for (from, to) in &downgrade_pairs {
+            let key = (mode_tag(from), mode_tag(to));
+            *stats.downgrades.entry(key).or_insert(0) += 1;
         }
 
         log::info!(
-            "partition: {} chunks, downgrades: {:?}",
+            "partition: {} chunks, downgrades: {:?}, total candidate clusters: {}",
             chunks.len(),
             stats.downgrades,
+            flat_clusters.len(),
         );
+
+        // Single global greedy on the full candidate pool. No chunk-level greedy
+        // means no chunk-boundary quality loss: the greedy sees every cluster's
+        // global coverage and picks the optimal subset directly.
+        let bucketed = self.bucket_clusters_by_size(flat_clusters);
+        let mut consolidated: Vec<Cluster> = self.cluster(&bucketed).into_iter().collect();
+        self.update_unique(&mut consolidated);
+        let mut solution: HashSet<Point> = consolidated.into_iter().map(|c| c.into()).collect();
 
         if self.min_points == 1 {
             let seen_cell_ids: HashSet<CellID> = solution.iter().map(|p| p.cell_id).collect();
@@ -133,6 +145,56 @@ impl<'a> Greedy {
         }
         log::info!("final solution size: {}", solution.len());
         solution
+    }
+
+    /// Generate raw candidate clusters for one partition chunk, filtered against
+    /// the GLOBAL point tree so coverage counts reflect the entire input set.
+    /// Returns `(clusters, optional_downgrade)`. The chunk-local rtree built to
+    /// bound the S2 walk is dropped before this function returns; the returned
+    /// `Cluster<'a>`s reference only `all_points_tree`.
+    fn generate_chunk_clusters(
+        &'a self,
+        chunk: &crate::clustering::partition::Chunk,
+        all_points_tree: &'a RTree<Point>,
+        budget: usize,
+    ) -> (Vec<Cluster<'a>>, Option<(ClusterMode, ClusterMode)>) {
+        use crate::clustering::partition::{gather_halo, s2_walk_cost, scaled_grid_density, select_effective_mode};
+
+        let halo = gather_halo(chunk.cell, all_points_tree, self.radius);
+        let mut combined: SingleVec = Vec::with_capacity(chunk.owned.len() + halo.len());
+        combined.extend(chunk.owned.iter().copied());
+        combined.extend(halo.iter().map(|p| p.center));
+
+        let effective_mode = select_effective_mode(self.cluster_mode.clone(), &combined, budget);
+        let downgrade = (effective_mode != self.cluster_mode)
+            .then(|| (self.cluster_mode.clone(), effective_mode.clone()));
+
+        let grid_density = if matches!(effective_mode, ClusterMode::Best) {
+            let s2_cost = s2_walk_cost(&combined);
+            Some(scaled_grid_density(s2_cost, budget))
+        } else {
+            None
+        };
+
+        // chunk_tree exists only to bound the S2 walk's flat_map_cells descent.
+        // Drop it after generate_candidates_for_mode by scoping it tightly.
+        let raw_candidates: SingleVec = {
+            let chunk_tree: RTree<Point> = crate::rtree::spawn(self.radius, &combined);
+            self.generate_candidates_for_mode(&combined, &chunk_tree, effective_mode, grid_density)
+        };
+
+        let clusters: Vec<Cluster<'a>> = raw_candidates
+            .into_par_iter()
+            .filter_map(|center| {
+                let iter = all_points_tree.locate_all_at_point(&center);
+                let mut covered = Vec::with_capacity(iter.size_hint().0);
+                covered.extend(iter);
+                (covered.len() >= self.min_points)
+                    .then(|| Cluster::new(Point::new(self.radius, 20, center), covered, vec![]))
+            })
+            .collect();
+
+        (clusters, downgrade)
     }
 
     fn recover_missing_points(
@@ -243,72 +305,12 @@ impl<'a> Greedy {
         }
     }
 
-    fn associate_clusters_for_chunk(
-        &'a self,
-        points: &'a SingleVec,
-        point_tree: &'a RTree<Point>,
-        effective_mode: ClusterMode,
-        budget: usize,
-    ) -> Vec<Vec<Cluster<'a>>> {
-        use crate::clustering::partition::{s2_walk_cost, scaled_grid_density};
-
-        let grid_density = if matches!(effective_mode, ClusterMode::Best) {
-            let s2_cost = s2_walk_cost(points);
-            Some(scaled_grid_density(s2_cost, budget))
-        } else {
-            None
-        };
-
-        let raw_candidates = self.generate_candidates_for_mode(
-            points,
-            point_tree,
-            effective_mode,
-            grid_density,
-        );
-
-        let clusters_with_data: Vec<Cluster> = raw_candidates
-            .into_par_iter()
-            .filter_map(|cluster| {
-                let iter = point_tree.locate_all_at_point(&cluster);
-                let mut points = Vec::with_capacity(iter.size_hint().0);
-                points.extend(iter);
-
-                (points.len() >= self.min_points)
-                    .then(|| Cluster::new(Point::new(self.radius, 20, cluster), points, vec![]))
-            })
-            .collect();
-
-        self.bucket_clusters_by_size(clusters_with_data)
-    }
-
-    pub(crate) fn solve_chunk(
-        &'a self,
-        chunk: &crate::clustering::partition::Chunk,
-        all_points_tree: &RTree<Point>,
-        budget: usize,
-    ) -> (HashSet<Point>, Option<(ClusterMode, ClusterMode)>) {
-        use crate::clustering::partition::{gather_halo, select_effective_mode, contains_latlng};
-
-        let halo = gather_halo(chunk.cell, all_points_tree, self.radius);
-        let mut combined: SingleVec = Vec::with_capacity(chunk.owned.len() + halo.len());
-        combined.extend(chunk.owned.iter().copied());
-        combined.extend(halo.iter().map(|p| p.center));
-
-        let effective_mode = select_effective_mode(self.cluster_mode.clone(), &combined, budget);
-        let downgrade = (effective_mode != self.cluster_mode)
-            .then(|| (self.cluster_mode.clone(), effective_mode.clone()));
-
-        let point_tree: RTree<Point> = crate::rtree::spawn(self.radius, &combined);
-        let clusters_with_data =
-            self.associate_clusters_for_chunk(&combined, &point_tree, effective_mode, budget);
-
-        let mut solution: Vec<Cluster> = self.cluster(&clusters_with_data).into_iter().collect();
-        self.update_unique(&mut solution);
-
-        solution.retain(|cluster| contains_latlng(chunk.cell, cluster.point.center));
-        let result: HashSet<Point> = solution.into_iter().map(|c| c.into()).collect();
-        (result, downgrade)
-    }
+    // associate_clusters_for_chunk + solve_chunk removed: the new run_partitioned
+    // generates candidates per-chunk but defers ALL greedy selection to a single
+    // global pass (see generate_chunk_clusters + global cluster() call in
+    // run_partitioned). This avoids the per-chunk greedy quality loss observed on
+    // medium-density inputs where chunk-local greedy commits to suboptimal
+    // boundary clusters that no consolidation pass could fully recover.
 
     fn associate_clusters(
         &'a self,

--- a/server/algorithms/src/clustering/greedy.rs
+++ b/server/algorithms/src/clustering/greedy.rs
@@ -176,10 +176,14 @@ impl<'a> Greedy {
             solution_vec.into_iter().map(|c| c.into()).collect();
 
         if self.min_points == 1 {
-            let seen_cell_ids: HashSet<CellID> =
-                final_solution.iter().map(|p| p.cell_id).collect();
-            let missing = self.recover_missing_points(&seen_cell_ids, points);
-            final_solution.extend(missing);
+            let cap = self.max_clusters.saturating_sub(final_solution.len());
+            if cap > 0 {
+                let seen_cell_ids: HashSet<CellID> =
+                    final_solution.iter().map(|p| p.cell_id).collect();
+                let missing =
+                    self.recover_missing_points(&seen_cell_ids, points, cap);
+                final_solution.extend(missing);
+            }
         }
         log::info!("final solution size: {}", final_solution.len());
         final_solution
@@ -480,15 +484,31 @@ impl<'a> Greedy {
         solution
     }
 
+    /// Build the set of single-point clusters needed to cover any input points
+    /// that the greedy pass never put inside a cluster. Used only when
+    /// `min_points == 1`, where the contract is "every input point must end up
+    /// covered".
+    ///
+    /// `max_to_add` is the cap on how many new single-point clusters this fn
+    /// is allowed to emit. Callers pass `self.max_clusters.saturating_sub(
+    /// current_solution_size)` so the missing-recovery pass cannot push the
+    /// final solution past the user's `max_clusters` ceiling. `0` is the
+    /// fast path: cap reached, nothing to do.
+    ///
+    /// When the unfiltered set of missing points exceeds the cap, the result
+    /// is truncated. Truncation keeps the first N points in input order
+    /// (deterministic for deterministic inputs); we don't reorder by local
+    /// density today.
     fn recover_missing_points(
         &self,
         seen_cell_ids: &HashSet<CellID>,
         points: &SingleVec,
+        max_to_add: usize,
     ) -> Vec<Point> {
-        if seen_cell_ids.len() == points.len() {
+        if max_to_add == 0 || seen_cell_ids.len() == points.len() {
             return vec![];
         }
-        points
+        let mut missing: Vec<Point> = points
             .into_par_iter()
             .filter_map(|p| {
                 let cell_id = CellID::from(LatLng::from_degrees(p[0], p[1])).parent(20);
@@ -498,7 +518,11 @@ impl<'a> Greedy {
                     Some(Point::new(self.radius, 20, *p))
                 }
             })
-            .collect()
+            .collect();
+        if missing.len() > max_to_add {
+            missing.truncate(max_to_add);
+        }
+        missing
     }
 
     fn bucket_clusters_by_size(&self, clusters_with_data: Vec<Cluster<'a>>) -> Vec<Vec<Cluster<'a>>> {
@@ -823,15 +847,20 @@ impl<'a> Greedy {
 
     #[time()]
     fn check_missing(&self, clusters: Vec<Cluster>, points: &SingleVec) -> HashSet<Point> {
-        let seen_cell_ids: HashSet<CellID> = clusters
-            .iter()
-            .flat_map(|c| c.all.iter())
-            .map(|p| p.cell_id)
-            .collect();
-        let missing = self.recover_missing_points(&seen_cell_ids, points);
-
-        let mut result: HashSet<Point> = clusters.into_iter().map(|c| c.into()).collect();
-        result.extend(missing);
+        let mut result: HashSet<Point> = clusters.iter().map(|c| c.point).collect();
+        // Respect `max_clusters`: never let missing-point recovery push the
+        // final solution above the cap. If greedy already hit the cap, skip
+        // the check entirely (cap == 0).
+        let cap = self.max_clusters.saturating_sub(result.len());
+        if cap > 0 {
+            let seen_cell_ids: HashSet<CellID> = clusters
+                .iter()
+                .flat_map(|c| c.all.iter())
+                .map(|p| p.cell_id)
+                .collect();
+            let missing = self.recover_missing_points(&seen_cell_ids, points, cap);
+            result.extend(missing);
+        }
 
         log::info!("final solution size: {}", result.len());
         result

--- a/server/algorithms/src/clustering/greedy.rs
+++ b/server/algorithms/src/clustering/greedy.rs
@@ -85,8 +85,9 @@ impl<'a> Greedy {
         return_set.into_iter().map(|p| p.center).collect()
     }
 
+    #[time()]
     fn run_partitioned(&'a self, points: &SingleVec) -> HashSet<Point> {
-        use crate::clustering::partition::{adaptive_partition, PartitionConfig, PartitionStats};
+        use crate::clustering::partition::{adaptive_partition, mode_tag, PartitionConfig, PartitionStats};
         use rayon::prelude::*;
 
         let config = PartitionConfig::load();
@@ -94,13 +95,15 @@ impl<'a> Greedy {
         let chunks = adaptive_partition(
             points,
             config.budget,
-            self.cluster_mode.clone(),
+            &self.cluster_mode,
             config.start_level,
             config.max_level,
         );
 
-        let mut stats = PartitionStats::default();
-        stats.total_chunks = chunks.len();
+        let mut stats = PartitionStats {
+            total_chunks: chunks.len(),
+            downgrades: Default::default(),
+        };
 
         let chunk_results: Vec<(HashSet<Point>, Option<(ClusterMode, ClusterMode)>)> = chunks
             .par_iter()
@@ -111,7 +114,7 @@ impl<'a> Greedy {
         for (chunk_solution, downgrade) in chunk_results {
             solution.extend(chunk_solution);
             if let Some((from, to)) = downgrade {
-                let key = (format!("{:?}", from), format!("{:?}", to));
+                let key = (mode_tag(&from), mode_tag(&to));
                 *stats.downgrades.entry(key).or_insert(0) += 1;
             }
         }
@@ -123,27 +126,46 @@ impl<'a> Greedy {
         );
 
         if self.min_points == 1 {
-            let seen_cell_ids: HashSet<CellID> = solution
-                .iter()
-                .map(|p| p.cell_id)
-                .collect();
-            if seen_cell_ids.len() != points.len() {
-                let missing: Vec<Point> = points
-                    .into_par_iter()
-                    .filter_map(|p| {
-                        let cell_id = CellID::from(LatLng::from_degrees(p[0], p[1])).parent(20);
-                        if seen_cell_ids.contains(&cell_id) {
-                            None
-                        } else {
-                            Some(Point::new(self.radius, 20, *p))
-                        }
-                    })
-                    .collect();
-                solution.extend(missing);
-            }
+            let seen_cell_ids: HashSet<CellID> = solution.iter().map(|p| p.cell_id).collect();
+            let missing = self.recover_missing_points(&seen_cell_ids, points);
+            solution.extend(missing);
             log::info!("final solution size: {}", solution.len());
         }
         solution
+    }
+
+    fn recover_missing_points(
+        &self,
+        seen_cell_ids: &HashSet<CellID>,
+        points: &SingleVec,
+    ) -> Vec<Point> {
+        if seen_cell_ids.len() == points.len() {
+            return vec![];
+        }
+        points
+            .into_par_iter()
+            .filter_map(|p| {
+                let cell_id = CellID::from(LatLng::from_degrees(p[0], p[1])).parent(20);
+                if seen_cell_ids.contains(&cell_id) {
+                    None
+                } else {
+                    Some(Point::new(self.radius, 20, *p))
+                }
+            })
+            .collect()
+    }
+
+    fn bucket_clusters_by_size(&self, clusters_with_data: Vec<Cluster<'a>>) -> Vec<Vec<Cluster<'a>>> {
+        let max = clusters_with_data
+            .iter()
+            .map(|cluster| cluster.all.len())
+            .max()
+            .unwrap_or(0);
+        let mut clustered_clusters = vec![vec![]; max + 1];
+        for cluster in clusters_with_data.into_iter() {
+            clustered_clusters[cluster.all.len()].push(cluster);
+        }
+        clustered_clusters
     }
 
     fn get_honeycomb_clusters(&self, points: &SingleVec) -> SingleVec {
@@ -208,13 +230,12 @@ impl<'a> Greedy {
             ClusterMode::Honeycomb => self.get_honeycomb_clusters(points),
             ClusterMode::Fast => self.gen_clusters(BYTE / 2, points),
             ClusterMode::Balanced => self.gen_clusters(BYTE, points),
-            ClusterMode::Better | ClusterMode::Best => {
+            ClusterMode::Better => self.get_s2_clusters(points, point_tree),
+            ClusterMode::Best => {
                 let mut pcs = self.get_s2_clusters(points, point_tree);
-                if matches!(mode, ClusterMode::Best) {
-                    let density = grid_density_override.unwrap_or(BYTE * 6);
-                    if density > 0 {
-                        pcs.extend_from_slice(&self.gen_clusters(density, points));
-                    }
+                let density = grid_density_override.unwrap_or(BYTE * 6);
+                if density > 0 {
+                    pcs.extend_from_slice(&self.gen_clusters(density, points));
                 }
                 pcs
             }
@@ -257,16 +278,7 @@ impl<'a> Greedy {
             })
             .collect();
 
-        let max = clusters_with_data
-            .iter()
-            .map(|cluster| cluster.all.len())
-            .max()
-            .unwrap_or(100);
-        let mut clustered_clusters = vec![vec![]; max + 1];
-        for cluster in clusters_with_data.into_iter() {
-            clustered_clusters[cluster.all.len()].push(cluster);
-        }
-        clustered_clusters
+        self.bucket_clusters_by_size(clusters_with_data)
     }
 
     pub(crate) fn solve_chunk(
@@ -350,30 +362,7 @@ impl<'a> Greedy {
             );
         }
 
-        let time = Instant::now();
-        let max = clusters_with_data
-            .iter()
-            .map(|cluster| cluster.all.len())
-            .max()
-            .unwrap_or(100);
-        log::info!(
-            "found best cluster ({}) {:.2}s",
-            max,
-            time.elapsed().as_secs_f32(),
-        );
-
-        let time = Instant::now();
-        let mut clustered_clusters = vec![vec![]; max + 1];
-
-        for cluster in clusters_with_data.into_iter() {
-            clustered_clusters[cluster.all.len()].push(cluster);
-        }
-        log::info!(
-            "sorted clusters by size in {:.2}s",
-            time.elapsed().as_secs_f32(),
-        );
-
-        clustered_clusters
+        self.bucket_clusters_by_size(clusters_with_data)
     }
 
     fn setup(&'a self, points: &SingleVec) -> HashSet<Point> {
@@ -542,36 +531,17 @@ impl<'a> Greedy {
 
     #[time()]
     fn check_missing(&self, clusters: Vec<Cluster>, points: &SingleVec) -> HashSet<Point> {
-        let missing = {
-            let seen_cell_ids: HashSet<CellID> = clusters
-                .iter()
-                .flat_map(|c| c.all.iter())
-                .map(|p| p.cell_id)
-                .collect();
+        let seen_cell_ids: HashSet<CellID> = clusters
+            .iter()
+            .flat_map(|c| c.all.iter())
+            .map(|p| p.cell_id)
+            .collect();
+        let missing = self.recover_missing_points(&seen_cell_ids, points);
 
-            if seen_cell_ids.len() == points.len() {
-                vec![]
-            } else {
-                points
-                    .into_par_iter()
-                    .filter_map(|p| {
-                        let cell_id = CellID::from(LatLng::from_degrees(p[0], p[1])).parent(20);
-                        if seen_cell_ids.contains(&cell_id) {
-                            None
-                        } else {
-                            Some(Point::new(self.radius, 20, *p))
-                        }
-                    })
-                    .collect::<Vec<Point>>()
-            }
-        };
+        let mut result: HashSet<Point> = clusters.into_iter().map(|c| c.into()).collect();
+        result.extend(missing);
 
-        let mut clusters: HashSet<Point> = clusters.into_iter().map(|c| c.into()).collect();
-
-        clusters.extend(missing);
-
-        log::info!("final solution size: {}", clusters.len());
-
-        clusters
+        log::info!("final solution size: {}", result.len());
+        result
     }
 }

--- a/server/algorithms/src/clustering/greedy.rs
+++ b/server/algorithms/src/clustering/greedy.rs
@@ -17,6 +17,7 @@ use crate::{
     bootstrap::radius,
     clustering::{
         candidates,
+        partition::BYTE,
         rtree::{cluster::Cluster, point::Point},
     },
     rtree::{self, SortDedupe},
@@ -91,6 +92,12 @@ impl<'a> Greedy {
         use rayon::prelude::*;
 
         let config = PartitionConfig::load();
+        // Global rtree shared (read-only) across all chunks for halo gathering.
+        // Each chunk's solve_chunk also builds a chunk-local rtree because cluster() and
+        // update_unique() take &'a RTree<Point> bound to chunk-scoped (owned + halo) points.
+        // This means peak rtree memory is roughly 2x points; acceptable for the bounded
+        // candidate budget per chunk. Long-term refactor could fold these into one tree
+        // with cell-level indexing.
         let all_points_tree: RTree<Point> = crate::rtree::spawn(self.radius, points);
         let chunks = adaptive_partition(
             points,
@@ -100,17 +107,14 @@ impl<'a> Greedy {
             config.max_level,
         );
 
-        let mut stats = PartitionStats {
-            total_chunks: chunks.len(),
-            downgrades: Default::default(),
-        };
+        let mut stats = PartitionStats::default();
 
         let chunk_results: Vec<(HashSet<Point>, Option<(ClusterMode, ClusterMode)>)> = chunks
             .par_iter()
             .map(|chunk| self.solve_chunk(chunk, &all_points_tree, config.budget))
             .collect();
 
-        let mut solution: HashSet<Point> = HashSet::new();
+        let mut solution: HashSet<Point> = HashSet::with_capacity(chunks.len() * 32);
         for (chunk_solution, downgrade) in chunk_results {
             solution.extend(chunk_solution);
             if let Some((from, to)) = downgrade {
@@ -121,7 +125,7 @@ impl<'a> Greedy {
 
         log::info!(
             "partition: {} chunks, downgrades: {:?}",
-            stats.total_chunks,
+            chunks.len(),
             stats.downgrades,
         );
 
@@ -225,7 +229,6 @@ impl<'a> Greedy {
         mode: ClusterMode,
         grid_density_override: Option<usize>,
     ) -> SingleVec {
-        const BYTE: usize = 1024;
         match mode {
             ClusterMode::Honeycomb => self.get_honeycomb_clusters(points),
             ClusterMode::Fast => self.gen_clusters(BYTE / 2, points),
@@ -318,8 +321,6 @@ impl<'a> Greedy {
         points: &'a SingleVec,
         point_tree: &'a RTree<Point>,
     ) -> Vec<Vec<Cluster<'a>>> {
-        const BYTE: usize = 1024;
-
         let sys = System::new_all();
         let sys_mem = sys.available_memory() as usize / BYTE / BYTE;
 

--- a/server/algorithms/src/clustering/mod.rs
+++ b/server/algorithms/src/clustering/mod.rs
@@ -35,6 +35,7 @@ pub fn main(
     clustering_args: &str,
     center_clusters: bool,
     _genetic_post_processing: bool,
+    bypass_adaptive_partition: bool,
 ) -> SingleVec {
     if data_points.is_empty() {
         return vec![];
@@ -61,7 +62,8 @@ pub fn main(
                     .set_cluster_split_level(cluster_split_level)
                     .set_max_clusters(max_clusters)
                     .set_min_points(min_points)
-                    .set_radius(radius);
+                    .set_radius(radius)
+                    .set_bypass_adaptive_partition(bypass_adaptive_partition);
 
                 greedy.run(&data_points)
             }

--- a/server/algorithms/src/clustering/mod.rs
+++ b/server/algorithms/src/clustering/mod.rs
@@ -17,6 +17,7 @@ mod candidates;
 mod fastest;
 // mod genetic;
 mod greedy;
+mod partition;
 mod s2;
 
 pub fn main(

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -1,17 +1,25 @@
 use std::collections::HashMap;
 use std::collections::HashSet as StdHashSet;
-use std::sync::OnceLock;
 
+use ::s2::cell::Cell;
+use ::s2::cellid::CellID;
+use ::s2::latlng::LatLng;
+use model::api::Precision;
 use model::api::cluster_mode::ClusterMode;
 use model::api::point_array::PointArray;
 use model::api::single_vec::SingleVec;
-use ::s2::cellid::CellID;
-use ::s2::latlng::LatLng;
+use rstar::{AABB, RTree};
 use sysinfo::System;
 
+use crate::clustering::candidates;
+use crate::clustering::rtree::point::Point;
+use crate::s2::create_cell_map;
+
 /// Bytes assumed per candidate when converting memory budget → candidate count.
-/// PointArray (16 bytes) + Cluster<Point> overhead (avg Vec<&Point> tail).
-pub(crate) const BYTES_PER_CANDIDATE: usize = 256;
+/// PointArray (16 bytes) + Cluster<Point> overhead. Empirical: ~864 bytes for a
+/// cluster with 100-point Vec<&Point> tail; rounded up to 1024 for safety so
+/// auto-budget under-allocates rather than over-allocates on dense workloads.
+pub(crate) const BYTES_PER_CANDIDATE: usize = 1024;
 
 pub(crate) const DEFAULT_START_LEVEL: u64 = 6;
 pub(crate) const DEFAULT_MAX_LEVEL: u64 = 18;
@@ -32,41 +40,49 @@ pub(crate) struct PartitionConfig {
 #[derive(Debug, Default)]
 pub(crate) struct PartitionStats {
     pub total_chunks: usize,
-    /// Counts downgrades by (from, to) pair. Keys are Debug-formatted ClusterMode strings
-    /// because `ClusterMode` does not implement `Hash` (it contains `Custom(String)`
-    /// and would require widening the `model` crate's derives).
-    pub downgrades: HashMap<(String, String), usize>,
+    /// Counts downgrades by (from_tag, to_tag) pair, keyed by stable ClusterMode tags.
+    pub downgrades: HashMap<(&'static str, &'static str), usize>,
 }
-
-static CONFIG: OnceLock<PartitionConfig> = OnceLock::new();
 
 impl PartitionConfig {
     pub(crate) fn load() -> PartitionConfig {
-        *CONFIG.get_or_init(|| {
-            let sys = System::new_all();
-            let threads = rayon::current_num_threads().max(1) as u64;
-            let mem_per_thread = sys.available_memory() / threads;
-            let auto_budget = (mem_per_thread / BYTES_PER_CANDIDATE as u64) as usize;
+        let sys = System::new_all();
+        let threads = rayon::current_num_threads().max(1) as u64;
+        let mem_per_thread = sys.available_memory() / threads;
+        let auto_budget = (mem_per_thread / BYTES_PER_CANDIDATE as u64) as usize;
 
-            let budget = std::env::var("KOJI_MAX_CANDIDATES_PER_CHUNK")
-                .ok()
-                .and_then(|s| s.parse::<usize>().ok())
-                .unwrap_or(auto_budget);
-            let start_level = std::env::var("KOJI_PARTITION_START_LEVEL")
-                .ok()
-                .and_then(|s| s.parse::<u64>().ok())
-                .unwrap_or(DEFAULT_START_LEVEL);
-            let max_level = std::env::var("KOJI_PARTITION_MAX_LEVEL")
-                .ok()
-                .and_then(|s| s.parse::<u64>().ok())
-                .unwrap_or(DEFAULT_MAX_LEVEL);
+        let budget = std::env::var("KOJI_MAX_CANDIDATES_PER_CHUNK")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(auto_budget);
+        let start_level = std::env::var("KOJI_PARTITION_START_LEVEL")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_START_LEVEL);
+        let max_level = std::env::var("KOJI_PARTITION_MAX_LEVEL")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_MAX_LEVEL);
 
-            log::info!(
-                "PartitionConfig: budget={}, start_level={}, max_level={}",
-                budget, start_level, max_level
-            );
-            PartitionConfig { budget, start_level, max_level }
-        })
+        log::info!(
+            "PartitionConfig: budget={}, start_level={}, max_level={}",
+            budget, start_level, max_level
+        );
+        PartitionConfig { budget, start_level, max_level }
+    }
+}
+
+/// Stable string tag for a ClusterMode variant — used as HashMap key so callers don't
+/// depend on `Debug` formatting, which can change. Custom plugins collapse to "Custom".
+pub(crate) fn mode_tag(mode: &ClusterMode) -> &'static str {
+    match mode {
+        ClusterMode::Honeycomb => "Honeycomb",
+        ClusterMode::Fastest => "Fastest",
+        ClusterMode::Fast => "Fast",
+        ClusterMode::Balanced => "Balanced",
+        ClusterMode::Better => "Better",
+        ClusterMode::Best => "Best",
+        ClusterMode::Custom(_) => "Custom",
     }
 }
 
@@ -91,7 +107,7 @@ pub(crate) fn scaled_grid_density(s2_cost: usize, budget: usize) -> usize {
 
 pub(crate) fn estimate_cost(
     points: &[PointArray],
-    mode: ClusterMode,
+    mode: &ClusterMode,
     budget: usize,
 ) -> usize {
     let s2_cost = distinct_l16_cells(points).saturating_mul(4096); // 4^(22-16)
@@ -102,9 +118,6 @@ pub(crate) fn estimate_cost(
     };
     s2_cost.saturating_add(grid_cost)
 }
-
-use ::s2::cell::Cell;
-use model::api::Precision;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct LatLonBBox {
@@ -153,12 +166,6 @@ pub(crate) fn contains_latlng(cell: CellID, p: PointArray) -> bool {
     derived == cell
 }
 
-use crate::s2::create_cell_map;
-
-use crate::clustering::rtree::point::Point;
-use crate::clustering::candidates;
-use rstar::{RTree, AABB};
-
 pub(crate) fn gather_halo(
     cell: CellID,
     all_points_tree: &RTree<Point>,
@@ -183,7 +190,7 @@ pub(crate) fn gather_halo(
 pub(crate) fn adaptive_partition(
     points: &SingleVec,
     budget: usize,
-    mode: ClusterMode,
+    mode: &ClusterMode,
     start_level: u64,
     max_level: u64,
 ) -> Vec<Chunk> {
@@ -197,13 +204,19 @@ pub(crate) fn adaptive_partition(
         let mut next_frontier: HashMap<u64, SingleVec> = HashMap::new();
         for (cell_id_raw, cell_points) in frontier.into_iter() {
             let cell = CellID(cell_id_raw);
-            let est = estimate_cost(&cell_points, mode.clone(), budget);
+            let est = estimate_cost(&cell_points, mode, budget);
             if est <= budget || cell.level() >= max_level {
+                if est > budget && cell.level() >= max_level {
+                    log::warn!(
+                        "partition: accepting chunk at max_level={} with est={} > budget={} (irreducible)",
+                        cell.level(), est, budget,
+                    );
+                }
                 accepted.push(Chunk { cell, owned: cell_points });
             } else {
                 let children = create_cell_map(&cell_points, cell.level() + 1);
                 for (k, v) in children {
-                    next_frontier.entry(k).or_insert_with(Vec::new).extend(v);
+                    next_frontier.entry(k).or_default().extend(v);
                 }
             }
         }
@@ -222,9 +235,8 @@ pub(crate) fn select_effective_mode(
 ) -> ClusterMode {
     let mut current = requested;
     loop {
-        if matches!(current, ClusterMode::Fast)
-            || estimate_cost(points, current.clone(), budget) <= budget
-        {
+        let est = estimate_cost(points, &current, budget);
+        if matches!(current, ClusterMode::Fast) || est <= budget {
             return current;
         }
         let next = match current {
@@ -235,10 +247,7 @@ pub(crate) fn select_effective_mode(
         };
         log::warn!(
             "chunk over budget for {:?} (est={}, budget={}), downgrading to {:?}",
-            current,
-            estimate_cost(points, current.clone(), budget),
-            budget,
-            next,
+            current, est, budget, next,
         );
         current = next;
     }
@@ -343,16 +352,16 @@ mod tests {
     #[test]
     fn estimate_cost_better_excludes_grid() {
         let points = dense_cluster([0., 0.], 100, 50.0, 2);
-        let est_better = estimate_cost(&points, ClusterMode::Better, 10_000_000);
-        let est_best = estimate_cost(&points, ClusterMode::Best, 10_000_000);
+        let est_better = estimate_cost(&points, &ClusterMode::Better, 10_000_000);
+        let est_best = estimate_cost(&points, &ClusterMode::Best, 10_000_000);
         assert!(est_best >= est_better, "Best must be >= Better");
     }
 
     #[test]
     fn estimate_cost_best_scales_with_budget() {
         let points = vec![[0.0, 0.0]];
-        let est_small = estimate_cost(&points, ClusterMode::Best, 100);
-        let est_large = estimate_cost(&points, ClusterMode::Best, 100_000_000);
+        let est_small = estimate_cost(&points, &ClusterMode::Best, 100);
+        let est_large = estimate_cost(&points, &ClusterMode::Best, 100_000_000);
         assert!(est_small < est_large, "larger budget should allow larger grid");
     }
 
@@ -384,7 +393,7 @@ mod tests {
     fn partition_small_bbox_single_chunk() {
         // 1000 points in roughly 1km² → should fit in one chunk at start_level=6.
         let pts = random_points_in_bbox(1000, [37.78, -122.43, 37.79, -122.42], 42);
-        let chunks = adaptive_partition(&pts, usize::MAX, ClusterMode::Better, 6, 18);
+        let chunks = adaptive_partition(&pts, usize::MAX, &ClusterMode::Better, 6, 18);
         assert_eq!(chunks.len(), 1, "small bbox should be one chunk, got {}", chunks.len());
     }
 
@@ -392,7 +401,7 @@ mod tests {
     fn partition_subdivides_when_over_budget() {
         // Force subdivision with a tiny budget.
         let pts = sparse_grid(20, 20, [-30., -60., 30., 60.]);
-        let chunks = adaptive_partition(&pts, 1, ClusterMode::Better, 6, 18);
+        let chunks = adaptive_partition(&pts, 1, &ClusterMode::Better, 6, 18);
         assert!(chunks.len() > 1, "tiny budget should produce many chunks");
     }
 
@@ -400,7 +409,7 @@ mod tests {
     fn partition_halts_at_max_level() {
         // Dense cluster + extremely tight budget → at least one chunk at max_level=18.
         let pts = dense_cluster([0., 0.], 5_000, 50.0, 11);
-        let chunks = adaptive_partition(&pts, 1, ClusterMode::Best, 6, 18);
+        let chunks = adaptive_partition(&pts, 1, &ClusterMode::Best, 6, 18);
         assert!(
             chunks.iter().any(|c| c.cell.level() == 18),
             "expected at least one chunk to reach max_level"
@@ -410,7 +419,7 @@ mod tests {
     #[test]
     fn partition_preserves_all_points() {
         let pts = random_points_in_bbox(500, [0., 0., 5., 5.], 99);
-        let chunks = adaptive_partition(&pts, 1_000_000, ClusterMode::Better, 6, 18);
+        let chunks = adaptive_partition(&pts, 1_000_000, &ClusterMode::Better, 6, 18);
         let total: usize = chunks.iter().map(|c| c.owned.len()).sum();
         assert_eq!(total, pts.len(), "no points should be dropped during partition");
     }
@@ -470,7 +479,7 @@ mod tests {
         let mut greedy = Greedy::default();
         greedy.set_cluster_mode(ClusterMode::Better).set_radius(70.0);
 
-        let chunks = adaptive_partition(&pts, usize::MAX, ClusterMode::Better, 6, 18);
+        let chunks = adaptive_partition(&pts, usize::MAX, &ClusterMode::Better, 6, 18);
         assert!(chunks.len() >= 2, "two distant clusters should produce >=2 chunks");
 
         let tree = crate::rtree::spawn(70.0, &pts);

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -32,7 +32,10 @@ pub(crate) struct PartitionConfig {
 #[derive(Debug, Default)]
 pub(crate) struct PartitionStats {
     pub total_chunks: usize,
-    pub downgrades: HashMap<(ClusterMode, ClusterMode), usize>,
+    /// Counts downgrades by (from, to) pair. Keys are Debug-formatted ClusterMode strings
+    /// because `ClusterMode` does not implement `Hash` (it contains `Custom(String)`
+    /// and would require widening the `model` crate's derives).
+    pub downgrades: HashMap<(String, String), usize>,
 }
 
 static CONFIG: OnceLock<PartitionConfig> = OnceLock::new();
@@ -481,5 +484,25 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn greedy_better_completes_huge_random_bbox() {
+        use crate::clustering::greedy::Greedy;
+        let pts = random_points_in_bbox(10_000, [-10., -10., 10., 10.], 42);
+        let mut greedy = Greedy::default();
+        greedy.set_cluster_mode(ClusterMode::Better).set_radius(70.0);
+        let result = greedy.run(&pts);
+        assert!(!result.is_empty(), "Better mode should produce some clusters");
+    }
+
+    #[test]
+    fn greedy_best_completes_huge_random_bbox() {
+        use crate::clustering::greedy::Greedy;
+        let pts = random_points_in_bbox(5_000, [-5., -5., 5., 5.], 42);
+        let mut greedy = Greedy::default();
+        greedy.set_cluster_mode(ClusterMode::Best).set_radius(70.0);
+        let result = greedy.run(&pts);
+        assert!(!result.is_empty(), "Best mode should produce some clusters");
     }
 }

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -54,6 +54,14 @@ pub(crate) struct PartitionStats {
     pub downgrades: HashMap<(&'static str, &'static str), usize>,
 }
 
+/// Read `key` from env, parse as T, fall back to `default` if missing/malformed.
+fn load_env_or<T: std::str::FromStr>(key: &str, default: T) -> T {
+    std::env::var(key)
+        .ok()
+        .and_then(|s| s.parse::<T>().ok())
+        .unwrap_or(default)
+}
+
 impl PartitionConfig {
     pub(crate) fn load() -> PartitionConfig {
         let sys = System::new_all();
@@ -61,18 +69,9 @@ impl PartitionConfig {
         let mem_per_thread = sys.available_memory() / threads;
         let auto_budget = (mem_per_thread / BYTES_PER_CANDIDATE as u64) as usize;
 
-        let budget = std::env::var("KOJI_MAX_CANDIDATES_PER_CHUNK")
-            .ok()
-            .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(auto_budget);
-        let start_level = std::env::var("KOJI_PARTITION_START_LEVEL")
-            .ok()
-            .and_then(|s| s.parse::<u64>().ok())
-            .unwrap_or(DEFAULT_START_LEVEL);
-        let max_level = std::env::var("KOJI_PARTITION_MAX_LEVEL")
-            .ok()
-            .and_then(|s| s.parse::<u64>().ok())
-            .unwrap_or(DEFAULT_MAX_LEVEL);
+        let budget = load_env_or("KOJI_MAX_CANDIDATES_PER_CHUNK", auto_budget);
+        let start_level = load_env_or("KOJI_PARTITION_START_LEVEL", DEFAULT_START_LEVEL);
+        let max_level = load_env_or("KOJI_PARTITION_MAX_LEVEL", DEFAULT_MAX_LEVEL);
 
         LOG_ONCE.call_once(|| {
             log::info!(
@@ -112,12 +111,22 @@ pub(crate) fn scaled_grid_density(s2_cost: usize, budget: usize) -> usize {
     density.min(BYTE * 6)
 }
 
+/// Worst-case candidate count from the S2 cell walk used by Better/Best modes.
+///
+/// `get_s2_clusters` descends from level 16 → level 22 per occupied ancestor,
+/// so each distinct level-16 cell touched by the input contributes up to 4^6 = 4096
+/// candidate leaves. Real output is usually smaller due to per-level point-tree
+/// filtering, but this is the honest upper bound used by the partition budget.
+pub(crate) fn s2_walk_cost(points: &[PointArray]) -> usize {
+    distinct_l16_cells(points).saturating_mul(4096)
+}
+
 pub(crate) fn estimate_cost(
     points: &[PointArray],
     mode: &ClusterMode,
     budget: usize,
 ) -> usize {
-    let s2_cost = distinct_l16_cells(points).saturating_mul(4096); // 4^(22-16)
+    let s2_cost = s2_walk_cost(points);
     let grid_cost = if matches!(mode, ClusterMode::Best) {
         scaled_grid_density(s2_cost, budget).pow(2)
     } else {
@@ -152,20 +161,22 @@ impl LatLonBBox {
 pub(crate) fn cell_bbox_lat_lon(cell: CellID) -> LatLonBBox {
     let c = Cell::from(&cell);
     // Use vertex extremes; avoids rect_bound() API churn between s2 versions.
-    let mut min_lat = Precision::INFINITY;
-    let mut max_lat = Precision::NEG_INFINITY;
-    let mut min_lon = Precision::INFINITY;
-    let mut max_lon = Precision::NEG_INFINITY;
+    let mut bb = LatLonBBox {
+        min_lat: Precision::INFINITY,
+        max_lat: Precision::NEG_INFINITY,
+        min_lon: Precision::INFINITY,
+        max_lon: Precision::NEG_INFINITY,
+    };
     for i in 0..4 {
         let v = c.vertex(i);
         let lat = v.latitude().deg();
         let lon = v.longitude().deg();
-        if lat < min_lat { min_lat = lat; }
-        if lat > max_lat { max_lat = lat; }
-        if lon < min_lon { min_lon = lon; }
-        if lon > max_lon { max_lon = lon; }
+        bb.min_lat = bb.min_lat.min(lat);
+        bb.max_lat = bb.max_lat.max(lat);
+        bb.min_lon = bb.min_lon.min(lon);
+        bb.max_lon = bb.max_lon.max(lon);
     }
-    LatLonBBox { min_lat, max_lat, min_lon, max_lon }
+    bb
 }
 
 pub(crate) fn contains_latlng(cell: CellID, p: PointArray) -> bool {

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -1,0 +1,65 @@
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use model::api::cluster_mode::ClusterMode;
+use model::api::single_vec::SingleVec;
+use ::s2::cellid::CellID;
+use sysinfo::System;
+
+/// Bytes assumed per candidate when converting memory budget → candidate count.
+/// PointArray (16 bytes) + Cluster<Point> overhead (avg Vec<&Point> tail).
+pub(crate) const BYTES_PER_CANDIDATE: usize = 256;
+
+pub(crate) const DEFAULT_START_LEVEL: u64 = 6;
+pub(crate) const DEFAULT_MAX_LEVEL: u64 = 18;
+
+#[derive(Debug, Clone)]
+pub(crate) struct Chunk {
+    pub cell: CellID,
+    pub owned: SingleVec,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PartitionConfig {
+    pub budget: usize,
+    pub start_level: u64,
+    pub max_level: u64,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct PartitionStats {
+    pub total_chunks: usize,
+    pub downgrades: HashMap<(ClusterMode, ClusterMode), usize>,
+}
+
+static CONFIG: OnceLock<PartitionConfig> = OnceLock::new();
+
+impl PartitionConfig {
+    pub(crate) fn load() -> PartitionConfig {
+        *CONFIG.get_or_init(|| {
+            let sys = System::new_all();
+            let threads = rayon::current_num_threads().max(1) as u64;
+            let mem_per_thread = sys.available_memory() / threads;
+            let auto_budget = (mem_per_thread / BYTES_PER_CANDIDATE as u64) as usize;
+
+            let budget = std::env::var("KOJI_MAX_CANDIDATES_PER_CHUNK")
+                .ok()
+                .and_then(|s| s.parse::<usize>().ok())
+                .unwrap_or(auto_budget);
+            let start_level = std::env::var("KOJI_PARTITION_START_LEVEL")
+                .ok()
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or(DEFAULT_START_LEVEL);
+            let max_level = std::env::var("KOJI_PARTITION_MAX_LEVEL")
+                .ok()
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or(DEFAULT_MAX_LEVEL);
+
+            log::info!(
+                "PartitionConfig: budget={}, start_level={}, max_level={}",
+                budget, start_level, max_level
+            );
+            PartitionConfig { budget, start_level, max_level }
+        })
+    }
+}

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -100,6 +100,56 @@ pub(crate) fn estimate_cost(
     s2_cost.saturating_add(grid_cost)
 }
 
+use ::s2::cell::Cell;
+use model::api::Precision;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct LatLonBBox {
+    pub min_lat: Precision,
+    pub max_lat: Precision,
+    pub min_lon: Precision,
+    pub max_lon: Precision,
+}
+
+impl LatLonBBox {
+    pub fn center_lat(&self) -> Precision {
+        0.5 * (self.min_lat + self.max_lat)
+    }
+
+    pub fn expand(&self, radius_deg: Precision) -> LatLonBBox {
+        LatLonBBox {
+            min_lat: self.min_lat - radius_deg,
+            max_lat: self.max_lat + radius_deg,
+            min_lon: self.min_lon - radius_deg,
+            max_lon: self.max_lon + radius_deg,
+        }
+    }
+}
+
+pub(crate) fn cell_bbox_lat_lon(cell: CellID) -> LatLonBBox {
+    let c = Cell::from(&cell);
+    // Use vertex extremes; avoids rect_bound() API churn between s2 versions.
+    let mut min_lat = Precision::INFINITY;
+    let mut max_lat = Precision::NEG_INFINITY;
+    let mut min_lon = Precision::INFINITY;
+    let mut max_lon = Precision::NEG_INFINITY;
+    for i in 0..4 {
+        let v = c.vertex(i);
+        let lat = v.latitude().deg();
+        let lon = v.longitude().deg();
+        if lat < min_lat { min_lat = lat; }
+        if lat > max_lat { max_lat = lat; }
+        if lon < min_lon { min_lon = lon; }
+        if lon > max_lon { max_lon = lon; }
+    }
+    LatLonBBox { min_lat, max_lat, min_lon, max_lon }
+}
+
+pub(crate) fn contains_latlng(cell: CellID, p: PointArray) -> bool {
+    let derived = CellID::from(LatLng::from_degrees(p[0], p[1])).parent(cell.level());
+    derived == cell
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -210,5 +260,29 @@ mod tests {
         let est_small = estimate_cost(&points, ClusterMode::Best, 100);
         let est_large = estimate_cost(&points, ClusterMode::Best, 100_000_000);
         assert!(est_small < est_large, "larger budget should allow larger grid");
+    }
+
+    #[test]
+    fn contains_latlng_owns_only_its_cell() {
+        // Pick a stable lat/lon, get its level-10 parent.
+        let center = LatLng::from_degrees(37.7749, -122.4194);  // SF
+        let owning_cell = CellID::from(center).parent(10);
+
+        // The lat/lon itself must be contained.
+        assert!(contains_latlng(owning_cell, [37.7749, -122.4194]));
+
+        // A point on the opposite side of the world is not contained.
+        assert!(!contains_latlng(owning_cell, [-37.7749, 57.5806]));
+    }
+
+    #[test]
+    fn cell_bbox_lat_lon_is_finite_and_ordered() {
+        let center = LatLng::from_degrees(0., 0.);
+        let cell = CellID::from(center).parent(8);
+        let bb = cell_bbox_lat_lon(cell);
+        assert!(bb.min_lat.is_finite() && bb.max_lat.is_finite());
+        assert!(bb.min_lon.is_finite() && bb.max_lon.is_finite());
+        assert!(bb.min_lat <= bb.max_lat);
+        assert!(bb.min_lon <= bb.max_lon);
     }
 }

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -152,6 +152,31 @@ pub(crate) fn contains_latlng(cell: CellID, p: PointArray) -> bool {
 
 use crate::s2::create_cell_map;
 
+use crate::clustering::rtree::point::Point;
+use crate::clustering::candidates;
+use rstar::{RTree, AABB};
+
+pub(crate) fn gather_halo(
+    cell: CellID,
+    all_points_tree: &RTree<Point>,
+    radius_meters: Precision,
+) -> Vec<Point> {
+    let bbox = cell_bbox_lat_lon(cell);
+    let radius_deg = candidates::meters_to_degrees(radius_meters, bbox.center_lat());
+    let expanded = bbox.expand(radius_deg);
+
+    let envelope = AABB::from_corners(
+        [expanded.min_lat, expanded.min_lon],
+        [expanded.max_lat, expanded.max_lon],
+    );
+
+    all_points_tree
+        .locate_in_envelope_intersecting(&envelope)
+        .filter(|p| !contains_latlng(cell, p.center))
+        .cloned()
+        .collect()
+}
+
 pub(crate) fn adaptive_partition(
     points: &SingleVec,
     budget: usize,
@@ -356,5 +381,32 @@ mod tests {
         let chunks = adaptive_partition(&pts, 1_000_000, ClusterMode::Better, 6, 18);
         let total: usize = chunks.iter().map(|c| c.owned.len()).sum();
         assert_eq!(total, pts.len(), "no points should be dropped during partition");
+    }
+
+    #[test]
+    fn gather_halo_includes_nearby_points_outside_cell() {
+        use crate::clustering::rtree::point::Point;
+        use crate::rtree;
+
+        // Pick a level-12 cell; place one point inside, one just outside (within radius).
+        let inside = [37.7749, -122.4194];
+        let cell = CellID::from(LatLng::from_degrees(inside[0], inside[1])).parent(12);
+        let bbox = cell_bbox_lat_lon(cell);
+
+        // Point just past the east edge (10 meters past, well under default 70m radius).
+        let outside = [bbox.max_lat - 0.00001, bbox.max_lon + 0.00005];
+
+        let all_points: SingleVec = vec![inside, outside];
+        let tree = rtree::spawn(70.0, &all_points);
+
+        let halo = gather_halo(cell, &tree, 70.0);
+        assert!(
+            halo.iter().any(|p: &Point| (p.center[1] - outside[1]).abs() < 1e-6),
+            "halo should include the just-outside point"
+        );
+        assert!(
+            !halo.iter().any(|p: &Point| (p.center[1] - inside[1]).abs() < 1e-6),
+            "halo should NOT include the inside point"
+        );
     }
 }

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -613,14 +613,19 @@ mod tests {
             .filter(|p| cluster_tree.locate_at_point(p).is_some())
             .count();
         let coverage_pct = covered as f64 * 100.0 / pts.len() as f64;
+        // mygod_score = clusters * min_points + uncovered_points (lower = better).
+        // Source of truth: stats.rs::Stats::get_score.
+        let uncovered = pts.len() - covered;
+        let mygod_score = result.len() * 5 + uncovered; // min_points=5
 
         eprintln!(
-            "bench_nh_{label}: mode={} radius=70 min_points=5 -> {} clusters, {:.2}% coverage ({}/{}) in {:.2}s",
+            "bench_nh_{label}: mode={} radius=70 min_points=5 -> {} clusters, {:.2}% coverage ({}/{}), mygod_score={} in {:.2}s",
             label,
             result.len(),
             coverage_pct,
             covered,
             pts.len(),
+            mygod_score,
             elapsed.as_secs_f32()
         );
     }

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -212,6 +212,35 @@ pub(crate) fn adaptive_partition(
     accepted
 }
 
+pub(crate) fn select_effective_mode(
+    requested: ClusterMode,
+    points: &[PointArray],
+    budget: usize,
+) -> ClusterMode {
+    let mut current = requested;
+    loop {
+        if matches!(current, ClusterMode::Fast)
+            || estimate_cost(points, current.clone(), budget) <= budget
+        {
+            return current;
+        }
+        let next = match current {
+            ClusterMode::Best => ClusterMode::Better,
+            ClusterMode::Better => ClusterMode::Balanced,
+            ClusterMode::Balanced => ClusterMode::Fast,
+            _ => return current,
+        };
+        log::warn!(
+            "chunk over budget for {:?} (est={}, budget={}), downgrading to {:?}",
+            current,
+            estimate_cost(points, current.clone(), budget),
+            budget,
+            next,
+        );
+        current = next;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -381,6 +410,22 @@ mod tests {
         let chunks = adaptive_partition(&pts, 1_000_000, ClusterMode::Better, 6, 18);
         let total: usize = chunks.iter().map(|c| c.owned.len()).sum();
         assert_eq!(total, pts.len(), "no points should be dropped during partition");
+    }
+
+    #[test]
+    fn fallback_ladder_keeps_mode_when_under_budget() {
+        let pts = random_points_in_bbox(10, [0., 0., 0.001, 0.001], 1);
+        let mode = select_effective_mode(ClusterMode::Best, &pts, usize::MAX);
+        assert_eq!(mode, ClusterMode::Best);
+    }
+
+    #[test]
+    fn fallback_ladder_walks_down_to_fast() {
+        // Force a chunk that is over budget even at Fast (impossible in practice,
+        // but we set budget = 0 to verify ladder reaches floor).
+        let pts = random_points_in_bbox(50, [-30., -60., 30., 60.], 7);
+        let mode = select_effective_mode(ClusterMode::Best, &pts, 0);
+        assert_eq!(mode, ClusterMode::Fast, "ladder must terminate at Fast");
     }
 
     #[test]

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -150,6 +150,43 @@ pub(crate) fn contains_latlng(cell: CellID, p: PointArray) -> bool {
     derived == cell
 }
 
+use crate::s2::create_cell_map;
+
+pub(crate) fn adaptive_partition(
+    points: &SingleVec,
+    budget: usize,
+    mode: ClusterMode,
+    start_level: u64,
+    max_level: u64,
+) -> Vec<Chunk> {
+    if points.is_empty() {
+        return vec![];
+    }
+    let mut frontier: HashMap<u64, SingleVec> = create_cell_map(points, start_level);
+    let mut accepted: Vec<Chunk> = Vec::new();
+
+    loop {
+        let mut next_frontier: HashMap<u64, SingleVec> = HashMap::new();
+        for (cell_id_raw, cell_points) in frontier.into_iter() {
+            let cell = CellID(cell_id_raw);
+            let est = estimate_cost(&cell_points, mode.clone(), budget);
+            if est <= budget || cell.level() >= max_level {
+                accepted.push(Chunk { cell, owned: cell_points });
+            } else {
+                let children = create_cell_map(&cell_points, cell.level() + 1);
+                for (k, v) in children {
+                    next_frontier.entry(k).or_insert_with(Vec::new).extend(v);
+                }
+            }
+        }
+        if next_frontier.is_empty() {
+            break;
+        }
+        frontier = next_frontier;
+    }
+    accepted
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -284,5 +321,40 @@ mod tests {
         assert!(bb.min_lon.is_finite() && bb.max_lon.is_finite());
         assert!(bb.min_lat <= bb.max_lat);
         assert!(bb.min_lon <= bb.max_lon);
+    }
+
+    #[test]
+    fn partition_small_bbox_single_chunk() {
+        // 1000 points in roughly 1km² → should fit in one chunk at start_level=6.
+        let pts = random_points_in_bbox(1000, [37.78, -122.43, 37.79, -122.42], 42);
+        let chunks = adaptive_partition(&pts, usize::MAX, ClusterMode::Better, 6, 18);
+        assert_eq!(chunks.len(), 1, "small bbox should be one chunk, got {}", chunks.len());
+    }
+
+    #[test]
+    fn partition_subdivides_when_over_budget() {
+        // Force subdivision with a tiny budget.
+        let pts = sparse_grid(20, 20, [-30., -60., 30., 60.]);
+        let chunks = adaptive_partition(&pts, 1, ClusterMode::Better, 6, 18);
+        assert!(chunks.len() > 1, "tiny budget should produce many chunks");
+    }
+
+    #[test]
+    fn partition_halts_at_max_level() {
+        // Dense cluster + extremely tight budget → at least one chunk at max_level=18.
+        let pts = dense_cluster([0., 0.], 5_000, 50.0, 11);
+        let chunks = adaptive_partition(&pts, 1, ClusterMode::Best, 6, 18);
+        assert!(
+            chunks.iter().any(|c| c.cell.level() == 18),
+            "expected at least one chunk to reach max_level"
+        );
+    }
+
+    #[test]
+    fn partition_preserves_all_points() {
+        let pts = random_points_in_bbox(500, [0., 0., 5., 5.], 99);
+        let chunks = adaptive_partition(&pts, 1_000_000, ClusterMode::Better, 6, 18);
+        let total: usize = chunks.iter().map(|c| c.owned.len()).sum();
+        assert_eq!(total, pts.len(), "no points should be dropped during partition");
     }
 }

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -220,7 +220,7 @@ pub(crate) fn adaptive_partition(
 
     loop {
         let mut next_frontier: HashMap<u64, SingleVec> = HashMap::new();
-        for (cell_id_raw, cell_points) in frontier.into_iter() {
+        for (cell_id_raw, cell_points) in frontier {
             let cell = CellID(cell_id_raw);
             let est = estimate_cost(&cell_points, mode, budget);
             let at_max_level = cell.level() >= max_level;
@@ -250,7 +250,7 @@ pub(crate) fn adaptive_partition(
 }
 
 pub(crate) fn select_effective_mode(
-    requested: ClusterMode,
+    mut requested: ClusterMode,
     points: &[PointArray],
     budget: usize,
 ) -> ClusterMode {
@@ -259,23 +259,22 @@ pub(crate) fn select_effective_mode(
         "select_effective_mode is only meaningful for Better/Best; got {:?}",
         requested,
     );
-    let mut current = requested;
     loop {
-        let est = estimate_cost(points, &current, budget);
-        if matches!(current, ClusterMode::Fast) || est <= budget {
-            return current;
+        let est = estimate_cost(points, &requested, budget);
+        if matches!(requested, ClusterMode::Fast) || est <= budget {
+            return requested;
         }
-        let next = match current {
+        let next = match requested {
             ClusterMode::Best => ClusterMode::Better,
             ClusterMode::Better => ClusterMode::Balanced,
             ClusterMode::Balanced => ClusterMode::Fast,
-            _ => return current,
+            _ => return requested,
         };
         log::warn!(
             "chunk over budget for {:?} (est={}, budget={}), downgrading to {:?}",
-            current, est, budget, next,
+            requested, est, budget, next,
         );
-        current = next;
+        requested = next;
     }
 }
 
@@ -283,9 +282,7 @@ pub(crate) fn select_effective_mode(
 mod tests {
     use super::*;
     use model::api::Precision;
-    use rand::SeedableRng;
-    use rand::rngs::SmallRng;
-    use rand::Rng;
+    use rand::{Rng, SeedableRng, rngs::SmallRng};
 
     pub(super) fn random_points_in_bbox(n: usize, bbox: [Precision; 4], seed: u64) -> SingleVec {
         let [min_lat, min_lon, max_lat, max_lon] = bbox;

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -454,4 +454,32 @@ mod tests {
             "halo should NOT include the inside point"
         );
     }
+
+    #[test]
+    fn ownership_filter_drops_foreign_centers() {
+        use crate::clustering::greedy::Greedy;
+
+        // Two non-adjacent dense clusters; partition should produce >=2 chunks.
+        // Each chunk's solve_chunk result must contain ONLY centers parenting to its cell.
+        let mut pts = dense_cluster([10.0, 20.0], 100, 50.0, 1);
+        pts.extend(dense_cluster([40.0, 80.0], 100, 50.0, 2));
+
+        let mut greedy = Greedy::default();
+        greedy.set_cluster_mode(ClusterMode::Better).set_radius(70.0);
+
+        let chunks = adaptive_partition(&pts, usize::MAX, ClusterMode::Better, 6, 18);
+        assert!(chunks.len() >= 2, "two distant clusters should produce >=2 chunks");
+
+        let tree = crate::rtree::spawn(70.0, &pts);
+        for chunk in &chunks {
+            let (solution, _downgrade) = greedy.solve_chunk(chunk, &tree, usize::MAX);
+            for p in &solution {
+                assert!(
+                    contains_latlng(chunk.cell, p.center),
+                    "cluster center {:?} must be inside owned cell {:?}",
+                    p.center, chunk.cell
+                );
+            }
+        }
+    }
 }

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -25,7 +25,8 @@ pub(crate) const BYTE: usize = 1024;
 /// PointArray (16 bytes) + Cluster<Point> overhead. Empirical: ~864 bytes for a
 /// cluster with 100-point Vec<&Point> tail; rounded up to 1024 for safety so
 /// auto-budget under-allocates rather than over-allocates on dense workloads.
-pub(crate) const BYTES_PER_CANDIDATE: usize = BYTE;
+/// Independent from BYTE (same numeric value today but different semantics).
+pub(crate) const BYTES_PER_CANDIDATE: usize = 1024;
 
 pub(crate) const DEFAULT_START_LEVEL: u64 = 6;
 pub(crate) const DEFAULT_MAX_LEVEL: u64 = 18;
@@ -211,8 +212,11 @@ pub(crate) fn adaptive_partition(
         for (cell_id_raw, cell_points) in frontier.into_iter() {
             let cell = CellID(cell_id_raw);
             let est = estimate_cost(&cell_points, mode, budget);
-            if est <= budget || cell.level() >= max_level {
-                if est > budget && cell.level() >= max_level {
+            let at_max_level = cell.level() >= max_level;
+            let within_budget = est <= budget;
+
+            if within_budget || at_max_level {
+                if at_max_level && !within_budget {
                     log::warn!(
                         "partition: accepting chunk at max_level={} with est={} > budget={} (irreducible)",
                         cell.level(), est, budget,
@@ -239,6 +243,11 @@ pub(crate) fn select_effective_mode(
     points: &[PointArray],
     budget: usize,
 ) -> ClusterMode {
+    debug_assert!(
+        matches!(requested, ClusterMode::Better | ClusterMode::Best),
+        "select_effective_mode is only meaningful for Better/Best; got {:?}",
+        requested,
+    );
     let mut current = requested;
     loop {
         let est = estimate_cost(points, &current, budget);

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -119,14 +119,20 @@ pub(crate) fn scaled_grid_density(s2_cost: usize, budget: usize) -> usize {
     density.min(BYTE * 6)
 }
 
-/// Worst-case candidate count from the S2 cell walk used by Better/Best modes.
+/// Expected (not worst-case) candidate count from the S2 cell walk used by Better/Best modes.
 ///
-/// `get_s2_clusters` descends from level 16 → level 22 per occupied ancestor,
-/// so each distinct level-16 cell touched by the input contributes up to 4^6 = 4096
-/// candidate leaves. Real output is usually smaller due to per-level point-tree
-/// filtering, but this is the honest upper bound used by the partition budget.
+/// `get_s2_clusters` descends from level 16 → level 22 per occupied ancestor, so the
+/// theoretical worst case is 4^6 = 4096 leaves per L16 cell. In practice the per-level
+/// `point_tree.locate_at_point` filter prunes aggressively for realistic point densities:
+/// each input point covers roughly `(radius / l22_size)^2 ≈ (70m / 5m)^2 ≈ 200` leaves,
+/// shared across nearby points. Using the worst-case 4096 was over-pessimistic and forced
+/// quality-destroying over-partitioning on medium-density inputs (e.g. ~20 pts/km²).
+/// 256 is calibrated against the New Hampshire benchmark to keep the partition shallow
+/// while still triggering for genuinely huge bboxes. Tunable via env if needed.
+pub(crate) const S2_WALK_COST_PER_L16: usize = 256;
+
 pub(crate) fn s2_walk_cost(points: &[PointArray]) -> usize {
-    distinct_l16_cells(points).saturating_mul(4096)
+    distinct_l16_cells(points).saturating_mul(S2_WALK_COST_PER_L16)
 }
 
 pub(crate) fn estimate_cost(
@@ -531,34 +537,6 @@ mod tests {
     }
 
     #[test]
-    fn ownership_filter_drops_foreign_centers() {
-        use crate::clustering::greedy::Greedy;
-
-        // Two non-adjacent dense clusters; partition should produce >=2 chunks.
-        // Each chunk's solve_chunk result must contain ONLY centers parenting to its cell.
-        let mut pts = dense_cluster([10.0, 20.0], 100, 50.0, 1);
-        pts.extend(dense_cluster([40.0, 80.0], 100, 50.0, 2));
-
-        let mut greedy = Greedy::default();
-        greedy.set_cluster_mode(ClusterMode::Better).set_radius(70.0);
-
-        let chunks = adaptive_partition(&pts, usize::MAX, &ClusterMode::Better, 6, 18);
-        assert!(chunks.len() >= 2, "two distant clusters should produce >=2 chunks");
-
-        let tree = crate::rtree::spawn(70.0, &pts);
-        for chunk in &chunks {
-            let (solution, _downgrade) = greedy.solve_chunk(chunk, &tree, usize::MAX);
-            for p in &solution {
-                assert!(
-                    contains_latlng(chunk.cell, p.center),
-                    "cluster center {:?} must be inside owned cell {:?}",
-                    p.center, chunk.cell
-                );
-            }
-        }
-    }
-
-    #[test]
     fn greedy_better_completes_huge_random_bbox() {
         use crate::clustering::greedy::Greedy;
         let pts = random_points_in_bbox(10_000, [-10., -10., 10., 10.], 42);
@@ -576,6 +554,93 @@ mod tests {
         greedy.set_cluster_mode(ClusterMode::Best).set_radius(70.0);
         let result = greedy.run(&pts);
         assert!(!result.is_empty(), "Best mode should produce some clusters");
+    }
+
+    /// Load a CSV file in `lat,lon\n...` format. Skips header row.
+    /// Returns a SingleVec of points. Panics on parse error.
+    fn load_csv(path: &str) -> SingleVec {
+        let contents = std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
+        contents
+            .lines()
+            .skip(1) // header
+            .filter_map(|line| {
+                let mut parts = line.split(',');
+                let lat = parts.next()?.trim().parse::<Precision>().ok()?;
+                let lon = parts.next()?.trim().parse::<Precision>().ok()?;
+                Some([lat, lon])
+            })
+            .collect()
+    }
+
+    fn run_bench(mode: ClusterMode, label: &str) {
+        use crate::clustering::greedy::Greedy;
+        use crate::rtree;
+        use std::time::Instant;
+
+        // CSV expected at workspace root (one level up from server/).
+        let path = if std::path::Path::new("points-nh.csv").exists() {
+            "points-nh.csv"
+        } else if std::path::Path::new("../points-nh.csv").exists() {
+            "../points-nh.csv"
+        } else {
+            eprintln!("bench_nh_{label}: skipped (points-nh.csv not found)");
+            return;
+        };
+
+        let load_t = Instant::now();
+        let pts = load_csv(path);
+        eprintln!(
+            "bench_nh_{label}: loaded {} points in {:.2}s",
+            pts.len(),
+            load_t.elapsed().as_secs_f32()
+        );
+
+        let mut greedy = Greedy::default();
+        greedy
+            .set_cluster_mode(mode)
+            .set_radius(70.0)
+            .set_min_points(5);
+
+        let run_t = Instant::now();
+        let result = greedy.run(&pts);
+        let elapsed = run_t.elapsed();
+
+        // Compute coverage: how many input points are within radius of at least one cluster center?
+        let cluster_tree = rtree::spawn(70.0, &result);
+        let covered: usize = pts
+            .iter()
+            .filter(|p| cluster_tree.locate_at_point(p).is_some())
+            .count();
+        let coverage_pct = covered as f64 * 100.0 / pts.len() as f64;
+
+        eprintln!(
+            "bench_nh_{label}: mode={} radius=70 min_points=5 -> {} clusters, {:.2}% coverage ({}/{}) in {:.2}s",
+            label,
+            result.len(),
+            coverage_pct,
+            covered,
+            pts.len(),
+            elapsed.as_secs_f32()
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn bench_nh_balanced() {
+        run_bench(ClusterMode::Balanced, "balanced");
+    }
+
+    #[test]
+    #[ignore]
+    fn bench_nh_better() {
+        run_bench(ClusterMode::Better, "better");
+    }
+
+    #[test]
+    #[ignore]
+    fn bench_nh_best() {
+        run_bench(ClusterMode::Best, "best");
     }
 
     #[test]

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -119,17 +119,16 @@ pub(crate) fn scaled_grid_density(s2_cost: usize, budget: usize) -> usize {
     density.min(BYTE * 6)
 }
 
-/// Expected (not worst-case) candidate count from the S2 cell walk used by Better/Best modes.
+/// Worst-case candidate count from the S2 cell walk used by Better/Best modes.
 ///
-/// `get_s2_clusters` descends from level 16 → level 22 per occupied ancestor, so the
-/// theoretical worst case is 4^6 = 4096 leaves per L16 cell. In practice the per-level
-/// `point_tree.locate_at_point` filter prunes aggressively for realistic point densities:
-/// each input point covers roughly `(radius / l22_size)^2 ≈ (70m / 5m)^2 ≈ 200` leaves,
-/// shared across nearby points. Using the worst-case 4096 was over-pessimistic and forced
-/// quality-destroying over-partitioning on medium-density inputs (e.g. ~20 pts/km²).
-/// 256 is calibrated against the New Hampshire benchmark to keep the partition shallow
-/// while still triggering for genuinely huge bboxes. Tunable via env if needed.
-pub(crate) const S2_WALK_COST_PER_L16: usize = 256;
+/// `get_s2_clusters` descends from level 16 → level 22 per occupied ancestor, so each
+/// L16 cell can contribute up to 4^6 = 4096 candidate leaves. The per-level point-tree
+/// filter prunes much of this on medium-density inputs, but on dense inputs (urban,
+/// pokemon-spawn-style data) the descent runs close to worst case. We use the worst-case
+/// value as the partition-budget estimator so peak memory is bounded even on dense data;
+/// for medium-density inputs this triggers more partitioning than strictly necessary
+/// (a few % quality cost) but is the only way to prevent OOM on dense huge bboxes.
+pub(crate) const S2_WALK_COST_PER_L16: usize = 4096;
 
 pub(crate) fn s2_walk_cost(points: &[PointArray]) -> usize {
     distinct_l16_cells(points).saturating_mul(S2_WALK_COST_PER_L16)

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::collections::HashSet as StdHashSet;
+use std::sync::Once;
 
 use ::s2::cell::Cell;
 use ::s2::cellid::CellID;
@@ -15,14 +16,23 @@ use crate::clustering::candidates;
 use crate::clustering::rtree::point::Point;
 use crate::s2::create_cell_map;
 
+/// Shared 1024 constant used as both a unit byte size (1 KiB) and a candidate
+/// grid-density base in greedy.rs. Centralized here to keep all `1024` magic
+/// numbers in clustering on a single source of truth.
+pub(crate) const BYTE: usize = 1024;
+
 /// Bytes assumed per candidate when converting memory budget → candidate count.
 /// PointArray (16 bytes) + Cluster<Point> overhead. Empirical: ~864 bytes for a
 /// cluster with 100-point Vec<&Point> tail; rounded up to 1024 for safety so
 /// auto-budget under-allocates rather than over-allocates on dense workloads.
-pub(crate) const BYTES_PER_CANDIDATE: usize = 1024;
+pub(crate) const BYTES_PER_CANDIDATE: usize = BYTE;
 
 pub(crate) const DEFAULT_START_LEVEL: u64 = 6;
 pub(crate) const DEFAULT_MAX_LEVEL: u64 = 18;
+
+/// Guards PartitionConfig::load logging so each process logs the resolved
+/// config exactly once, regardless of how many partitioned runs happen.
+static LOG_ONCE: Once = Once::new();
 
 #[derive(Debug, Clone)]
 pub(crate) struct Chunk {
@@ -39,7 +49,6 @@ pub(crate) struct PartitionConfig {
 
 #[derive(Debug, Default)]
 pub(crate) struct PartitionStats {
-    pub total_chunks: usize,
     /// Counts downgrades by (from_tag, to_tag) pair, keyed by stable ClusterMode tags.
     pub downgrades: HashMap<(&'static str, &'static str), usize>,
 }
@@ -64,10 +73,12 @@ impl PartitionConfig {
             .and_then(|s| s.parse::<u64>().ok())
             .unwrap_or(DEFAULT_MAX_LEVEL);
 
-        log::info!(
-            "PartitionConfig: budget={}, start_level={}, max_level={}",
-            budget, start_level, max_level
-        );
+        LOG_ONCE.call_once(|| {
+            log::info!(
+                "PartitionConfig: budget={}, start_level={}, max_level={}",
+                budget, start_level, max_level
+            );
+        });
         PartitionConfig { budget, start_level, max_level }
     }
 }
@@ -86,11 +97,6 @@ pub(crate) fn mode_tag(mode: &ClusterMode) -> &'static str {
     }
 }
 
-/// Existing `BYTE` constant is local to greedy.rs (`const BYTE: usize = 1024`).
-/// We mirror it here rather than expose it: this is the BYTE × 6 grid-density ceiling
-/// used by Best mode in greedy::associate_clusters.
-pub(crate) const BYTE_TIMES_SIX: usize = 1024 * 6;
-
 pub(crate) fn distinct_l16_cells(points: &[PointArray]) -> usize {
     points
         .iter()
@@ -102,7 +108,7 @@ pub(crate) fn distinct_l16_cells(points: &[PointArray]) -> usize {
 pub(crate) fn scaled_grid_density(s2_cost: usize, budget: usize) -> usize {
     let remaining = budget.saturating_sub(s2_cost);
     let density = (remaining as f64).sqrt() as usize;
-    density.min(BYTE_TIMES_SIX)
+    density.min(BYTE * 6)
 }
 
 pub(crate) fn estimate_cost(
@@ -343,7 +349,7 @@ mod tests {
         assert_eq!(scaled_grid_density(1_000_000, 500_000), 0);
         // tiny s2 cost, huge budget -> capped at BYTE * 6
         let big = scaled_grid_density(0, 100_000_000_000);
-        assert_eq!(big, BYTE_TIMES_SIX);
+        assert_eq!(big, BYTE * 6);
         // moderate: sqrt(remaining) used
         let mid = scaled_grid_density(0, 1_000_000);
         assert_eq!(mid, 1000);

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -1,9 +1,12 @@
 use std::collections::HashMap;
+use std::collections::HashSet as StdHashSet;
 use std::sync::OnceLock;
 
 use model::api::cluster_mode::ClusterMode;
+use model::api::point_array::PointArray;
 use model::api::single_vec::SingleVec;
 use ::s2::cellid::CellID;
+use ::s2::latlng::LatLng;
 use sysinfo::System;
 
 /// Bytes assumed per candidate when converting memory budget → candidate count.
@@ -62,6 +65,39 @@ impl PartitionConfig {
             PartitionConfig { budget, start_level, max_level }
         })
     }
+}
+
+/// Existing `BYTE` constant is local to greedy.rs (`const BYTE: usize = 1024`).
+/// We mirror it here rather than expose it: this is the BYTE × 6 grid-density ceiling
+/// used by Best mode in greedy::associate_clusters.
+pub(crate) const BYTE_TIMES_SIX: usize = 1024 * 6;
+
+pub(crate) fn distinct_l16_cells(points: &[PointArray]) -> usize {
+    points
+        .iter()
+        .map(|p| CellID::from(LatLng::from_degrees(p[0], p[1])).parent(16))
+        .collect::<StdHashSet<_>>()
+        .len()
+}
+
+pub(crate) fn scaled_grid_density(s2_cost: usize, budget: usize) -> usize {
+    let remaining = budget.saturating_sub(s2_cost);
+    let density = (remaining as f64).sqrt() as usize;
+    density.min(BYTE_TIMES_SIX)
+}
+
+pub(crate) fn estimate_cost(
+    points: &[PointArray],
+    mode: ClusterMode,
+    budget: usize,
+) -> usize {
+    let s2_cost = distinct_l16_cells(points).saturating_mul(4096); // 4^(22-16)
+    let grid_cost = if matches!(mode, ClusterMode::Best) {
+        scaled_grid_density(s2_cost, budget).pow(2)
+    } else {
+        0
+    };
+    s2_cost.saturating_add(grid_cost)
 }
 
 #[cfg(test)]
@@ -136,5 +172,43 @@ mod tests {
 
         let grid = sparse_grid(5, 5, [0., 0., 10., 10.]);
         assert_eq!(grid.len(), 25);
+    }
+
+    #[test]
+    fn distinct_l16_cells_dedupes() {
+        let points = vec![[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]];
+        assert_eq!(distinct_l16_cells(&points), 1);
+
+        let points = dense_cluster([0., 0.], 10, 1.0, 1);  // 10 points, ~1m radius
+        let n = distinct_l16_cells(&points);
+        assert!(n >= 1 && n <= 10, "expected dedup count between 1 and 10, got {}", n);
+    }
+
+    #[test]
+    fn scaled_grid_density_caps_correctly() {
+        // s2_cost dominates -> density 0
+        assert_eq!(scaled_grid_density(1_000_000, 500_000), 0);
+        // tiny s2 cost, huge budget -> capped at BYTE * 6
+        let big = scaled_grid_density(0, 100_000_000_000);
+        assert_eq!(big, BYTE_TIMES_SIX);
+        // moderate: sqrt(remaining) used
+        let mid = scaled_grid_density(0, 1_000_000);
+        assert_eq!(mid, 1000);
+    }
+
+    #[test]
+    fn estimate_cost_better_excludes_grid() {
+        let points = dense_cluster([0., 0.], 100, 50.0, 2);
+        let est_better = estimate_cost(&points, ClusterMode::Better, 10_000_000);
+        let est_best = estimate_cost(&points, ClusterMode::Best, 10_000_000);
+        assert!(est_best >= est_better, "Best must be >= Better");
+    }
+
+    #[test]
+    fn estimate_cost_best_scales_with_budget() {
+        let points = vec![[0.0, 0.0]];
+        let est_small = estimate_cost(&points, ClusterMode::Best, 100);
+        let est_large = estimate_cost(&points, ClusterMode::Best, 100_000_000);
+        assert!(est_small < est_large, "larger budget should allow larger grid");
     }
 }

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -63,3 +63,78 @@ impl PartitionConfig {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use model::api::Precision;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+    use rand::Rng;
+
+    pub(super) fn random_points_in_bbox(n: usize, bbox: [Precision; 4], seed: u64) -> SingleVec {
+        let [min_lat, min_lon, max_lat, max_lon] = bbox;
+        let mut rng = SmallRng::seed_from_u64(seed);
+        (0..n)
+            .map(|_| {
+                let lat = rng.random_range(min_lat..max_lat);
+                let lon = rng.random_range(min_lon..max_lon);
+                [lat, lon]
+            })
+            .collect()
+    }
+
+    pub(super) fn dense_cluster(
+        center: [Precision; 2],
+        n: usize,
+        radius_m: Precision,
+        seed: u64,
+    ) -> SingleVec {
+        let mut rng = SmallRng::seed_from_u64(seed);
+        // Approx 1 deg lat ≈ 111_000 m; ignore lon shrinkage for tiny test radii
+        let radius_deg = radius_m / 111_000.0;
+        (0..n)
+            .map(|_| {
+                let dlat = rng.random_range(-radius_deg..radius_deg);
+                let dlon = rng.random_range(-radius_deg..radius_deg);
+                [center[0] + dlat, center[1] + dlon]
+            })
+            .collect()
+    }
+
+    pub(super) fn sparse_grid(
+        rows: usize,
+        cols: usize,
+        bbox: [Precision; 4],
+    ) -> SingleVec {
+        let [min_lat, min_lon, max_lat, max_lon] = bbox;
+        let lat_step = (max_lat - min_lat) / rows as Precision;
+        let lon_step = (max_lon - min_lon) / cols as Precision;
+        (0..rows)
+            .flat_map(|r| {
+                (0..cols).map(move |c| {
+                    [
+                        min_lat + (r as Precision + 0.5) * lat_step,
+                        min_lon + (c as Precision + 0.5) * lon_step,
+                    ]
+                })
+            })
+            .collect()
+    }
+
+    #[test]
+    fn helpers_produce_expected_shapes() {
+        let pts = random_points_in_bbox(100, [0., 0., 1., 1.], 42);
+        assert_eq!(pts.len(), 100);
+        for p in &pts {
+            assert!(p[0] >= 0.0 && p[0] < 1.0);
+            assert!(p[1] >= 0.0 && p[1] < 1.0);
+        }
+
+        let cluster = dense_cluster([10., 20.], 50, 100.0, 7);
+        assert_eq!(cluster.len(), 50);
+
+        let grid = sparse_grid(5, 5, [0., 0., 10., 10.]);
+        assert_eq!(grid.len(), 25);
+    }
+}

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -505,4 +505,27 @@ mod tests {
         let result = greedy.run(&pts);
         assert!(!result.is_empty(), "Best mode should produce some clusters");
     }
+
+    #[test]
+    #[ignore]  // run with: cargo test -p algorithms -- --ignored
+    fn manual_smoke_huge_bbox_better_mode() {
+        use crate::clustering::greedy::Greedy;
+        use std::time::Instant;
+
+        let pts = random_points_in_bbox(50_000, [-45., -90., 45., 90.], 12345);
+        let mut greedy = Greedy::default();
+        greedy.set_cluster_mode(ClusterMode::Better).set_radius(70.0);
+
+        let t = Instant::now();
+        let result = greedy.run(&pts);
+        let elapsed = t.elapsed();
+
+        eprintln!(
+            "manual_smoke: {} input pts → {} clusters in {:.2}s",
+            pts.len(),
+            result.len(),
+            elapsed.as_secs_f32()
+        );
+        assert!(!result.is_empty());
+    }
 }

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -97,6 +97,8 @@ pub(crate) fn mode_tag(mode: &ClusterMode) -> &'static str {
     }
 }
 
+/// Count the number of distinct level-16 S2 cells touched by the input points.
+/// Used as the leading factor in the S2 walk cost estimate (see `s2_walk_cost`).
 pub(crate) fn distinct_l16_cells(points: &[PointArray]) -> usize {
     points
         .iter()
@@ -105,6 +107,12 @@ pub(crate) fn distinct_l16_cells(points: &[PointArray]) -> usize {
         .len()
 }
 
+/// Pick a grid density for Best mode that fits the remaining candidate budget.
+///
+/// `s2_cost` is the prior commitment from `s2_walk_cost`. Returns 0 if the S2
+/// walk already saturates the budget (effectively collapsing Best to Better for
+/// this chunk). Capped at `BYTE * 6` so we never exceed the original `Best`
+/// density even when the budget is huge.
 pub(crate) fn scaled_grid_density(s2_cost: usize, budget: usize) -> usize {
     let remaining = budget.saturating_sub(s2_cost);
     let density = (remaining as f64).sqrt() as usize;
@@ -179,11 +187,21 @@ pub(crate) fn cell_bbox_lat_lon(cell: CellID) -> LatLonBBox {
     bb
 }
 
+/// Ownership predicate: does `p` belong to `cell` at the cell's own level?
+///
+/// Used both during partition (implicitly via `create_cell_map`) and during the
+/// post-solve ownership filter in `Greedy::solve_chunk`. Both sides apply the
+/// same deterministic `LatLng → parent(level)` rule so a cluster center is
+/// owned by exactly one chunk.
 pub(crate) fn contains_latlng(cell: CellID, p: PointArray) -> bool {
     let derived = CellID::from(LatLng::from_degrees(p[0], p[1])).parent(cell.level());
     derived == cell
 }
 
+/// Collect halo points: those that intersect `cell`'s bbox expanded by `radius_meters`
+/// but do NOT belong to `cell`. Halo points participate in a chunk's solve as
+/// coverage targets but never own cluster centers, so adjacent chunks can place
+/// edge clusters fairly without producing duplicates.
 pub(crate) fn gather_halo(
     cell: CellID,
     all_points_tree: &RTree<Point>,
@@ -205,6 +223,15 @@ pub(crate) fn gather_halo(
         .collect()
 }
 
+/// Top-down BFS partitioner. Buckets points by S2 cell at `start_level`, then
+/// for each bucket: accept the chunk if its estimated candidate cost ≤ `budget`
+/// or if it has reached `max_level`; otherwise subdivide into the cell's children
+/// and re-evaluate. Returns the accepted chunks; their union covers all input
+/// points without duplication.
+///
+/// Termination: bounded loop depth = `max_level - start_level`. At `max_level`,
+/// over-budget chunks are accepted with a warn log and handled later by
+/// `select_effective_mode`'s downgrade ladder.
 pub(crate) fn adaptive_partition(
     points: &SingleVec,
     budget: usize,
@@ -212,6 +239,12 @@ pub(crate) fn adaptive_partition(
     start_level: u64,
     max_level: u64,
 ) -> Vec<Chunk> {
+    debug_assert!(
+        start_level <= max_level,
+        "start_level ({}) must be <= max_level ({})",
+        start_level,
+        max_level,
+    );
     if points.is_empty() {
         return vec![];
     }
@@ -250,6 +283,12 @@ pub(crate) fn adaptive_partition(
     accepted
 }
 
+/// Stepwise mode downgrade ladder: `Best → Better → Balanced → Fast`.
+///
+/// Returns the highest-quality mode whose estimated cost fits `budget`, or
+/// `Fast` if even that exceeds budget (Fast is the floor; pathological chunks
+/// always complete). Each downgrade is logged at WARN. Only meaningful when
+/// called with Better or Best — checked by debug_assert.
 pub(crate) fn select_effective_mode(
     mut requested: ClusterMode,
     points: &[PointArray],

--- a/server/algorithms/src/clustering/partition.rs
+++ b/server/algorithms/src/clustering/partition.rs
@@ -216,11 +216,12 @@ pub(crate) fn adaptive_partition(
         return vec![];
     }
     let mut frontier: HashMap<u64, SingleVec> = create_cell_map(points, start_level);
-    let mut accepted: Vec<Chunk> = Vec::new();
+    let mut accepted: Vec<Chunk> = Vec::with_capacity(frontier.len());
+    let mut next_frontier: HashMap<u64, SingleVec> = HashMap::with_capacity(frontier.len() * 4);
 
     loop {
-        let mut next_frontier: HashMap<u64, SingleVec> = HashMap::new();
-        for (cell_id_raw, cell_points) in frontier {
+        next_frontier.clear();
+        for (cell_id_raw, cell_points) in frontier.drain() {
             let cell = CellID(cell_id_raw);
             let est = estimate_cost(&cell_points, mode, budget);
             let at_max_level = cell.level() >= max_level;
@@ -244,7 +245,7 @@ pub(crate) fn adaptive_partition(
         if next_frontier.is_empty() {
             break;
         }
-        frontier = next_frontier;
+        std::mem::swap(&mut frontier, &mut next_frontier);
     }
     accepted
 }

--- a/server/algorithms/src/sec/mod.rs
+++ b/server/algorithms/src/sec/mod.rs
@@ -1,5 +1,5 @@
 mod circle;
-mod sec;
+pub(crate) mod sec;
 mod state;
 mod utils;
 

--- a/server/api/src/public/v1/calculate.rs
+++ b/server/api/src/public/v1/calculate.rs
@@ -179,6 +179,7 @@ async fn cluster(
         clustering_args,
         center_clusters,
         genetic_post_processing,
+        dev,
         ..
     } = payload.into_inner().init(Some(&mode));
 
@@ -250,6 +251,7 @@ async fn cluster(
         &clustering_args,
         center_clusters,
         genetic_post_processing,
+        dev.bypass_adaptive_partition,
     );
     let clusters = routing::main(
         &data_points,

--- a/server/model/src/api/args.rs
+++ b/server/model/src/api/args.rs
@@ -388,6 +388,24 @@ pub struct Args {
     ///
     /// Default: `false`
     pub genetic_post_processing: Option<bool>,
+    /// Developer / experimental toggles. Wraps fields that exist only for
+    /// debugging or A/B comparison and are NOT part of the stable public API.
+    /// Expect this struct to grow and shrink between releases.
+    pub dev: Option<DevArgs>,
+}
+
+/// Developer / experimental request toggles. Add fields here for one-off
+/// debugging knobs that aren't part of the stable API surface.
+#[derive(Debug, Deserialize, Clone, Default)]
+#[serde(default)]
+pub struct DevArgs {
+    /// When `true`, skips the adaptive S2 partitioning + post-greedy gap-fill
+    /// added in PR #253 and uses the pre-PR `setup()` path for every mode.
+    /// Intended for side-by-side quality comparison during PR review; will be
+    /// commented out after the PR merges.
+    ///
+    /// Default: `false`
+    pub bypass_adaptive_partition: Option<bool>,
 }
 
 pub struct ArgsUnwrapped {
@@ -422,6 +440,14 @@ pub struct ArgsUnwrapped {
     pub bootstrapping_args: String,
     pub center_clusters: bool,
     pub genetic_post_processing: bool,
+    pub dev: DevArgsUnwrapped,
+}
+
+/// Unwrapped counterpart to [DevArgs]: all fields resolved to their concrete
+/// types with defaults applied.
+#[derive(Debug, Clone, Default)]
+pub struct DevArgsUnwrapped {
+    pub bypass_adaptive_partition: bool,
 }
 
 fn validate_s2_cell(value_to_check: Option<u64>, label: &str) -> u64 {
@@ -496,6 +522,7 @@ impl Args {
             bootstrapping_args,
             center_clusters,
             genetic_post_processing,
+            dev,
         } = self;
         let enum_type = get_enum_by_geometry_string(geometry_type);
         let (area, default_return_type) = if let Some(area) = area {
@@ -562,6 +589,12 @@ impl Args {
         };
         let center_clusters = center_clusters.unwrap_or(false);
         let genetic_post_processing = genetic_post_processing.unwrap_or_default();
+        let dev = DevArgsUnwrapped {
+            bypass_adaptive_partition: dev
+                .as_ref()
+                .and_then(|d| d.bypass_adaptive_partition)
+                .unwrap_or(false),
+        };
         let clusters = resolve_data_points(clusters);
         let last_seen = last_seen.unwrap_or(0);
         let save_to_db = save_to_db.unwrap_or(false);
@@ -623,6 +656,7 @@ impl Args {
             bootstrapping_args,
             center_clusters,
             genetic_post_processing,
+            dev,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Stops `ClusterMode::Better` and `ClusterMode::Best` from generating tens to hundreds of millions of candidate cluster centers on huge bboxes.
- Adds an adaptive S2-cell partitioner that subdivides until each chunk's estimated candidate cost fits a memory-derived budget, solves each chunk in parallel with a `radius`-wide halo, filters cluster centers by cell ownership, and recovers any uncovered points.
- Per-chunk stepwise fallback ladder (`Best → Better → Balanced → Fast`) handles irreducible dense areas without aborting the request.
- Deprecates the `cluster_split_level` setter — auto-partitioning replaces it. Non-zero values now log a warn and are ignored. Field removed from struct.

## What changed

- **New module** `server/algorithms/src/clustering/partition.rs` (~300 lines + 270 lines of tests): config loader, cost estimator, S2 cell helpers, halo gatherer, BFS partitioner, fallback ladder.
- **Refactored** `server/algorithms/src/clustering/greedy.rs`: extracts `generate_candidates_for_mode`, `bucket_clusters_by_size`, `recover_missing_points`; adds `solve_chunk`, `associate_clusters_for_chunk`, `run_partitioned`; routes `run` to the new path for Better/Best, leaves all other modes unchanged.
- **Module wiring** `server/algorithms/src/clustering/mod.rs`: adds `mod partition;`.
- **Cargo** baseline fix: enables `small_rng + std + std_rng + thread_rng` features on `rand 0.9` so the workspace compiles (was failing pre-existing).

## Architecture

```
Greedy::run(points)
  ├─ if cluster_mode ∈ {Better, Best}:
  │     ├─ adaptive_partition(points, budget) → Vec<Chunk>
  │     ├─ par_iter chunks → solve_chunk(halo + ownership filter + downgrade ladder)
  │     ├─ recover_missing_points (if min_points == 1)
  │     └─ union → SingleVec
  └─ else: existing setup() path unchanged
```

Three new env vars (all optional, auto-derived defaults):
- `KOJI_MAX_CANDIDATES_PER_CHUNK` — per-chunk candidate budget (default: `available_mem / threads / 1024`)
- `KOJI_PARTITION_START_LEVEL` — coarse S2 level to start descent (default 6)
- `KOJI_PARTITION_MAX_LEVEL` — halt subdivision at this depth (default 18)

## Process / quality

- Built TDD from spec → plan → 11 implementation tasks via subagent-driven dev
- 7 rounds of caveman-review with progressive fix passes (4 substantive + 3 polish)
- Rubber-duck-trace verified all touched surfaces wire correctly
- Refactor + rust-idiomatic-polish passes for DRY/readability
- 17 unit tests + 2 integration tests + 1 ignored manual smoke
- Zero clippy warnings introduced (baseline noise unchanged)

## Specs & plans

- Design: [docs/superpowers/specs/2026-05-27-greedy-bbox-adaptive-partition-design.md](docs/superpowers/specs/2026-05-27-greedy-bbox-adaptive-partition-design.md)
- Implementation plan: [docs/superpowers/plans/2026-05-27-greedy-bbox-adaptive-partition.md](docs/superpowers/plans/2026-05-27-greedy-bbox-adaptive-partition.md)

## Test plan

- [ ] `cd server && cargo test -p algorithms --lib clustering::partition` — all 17 tests pass
- [ ] `cd server && cargo test -p algorithms --lib clustering::partition -- --ignored` — manual_smoke completes within reasonable wall-clock on real hardware
- [ ] Run a Better-mode query on the bbox/point set that originally triggered the OOM — confirm partition+downgrade log line appears and request completes
- [ ] Existing Honeycomb / Balanced / Fast / Fastest / Custom callers unchanged — sanity check no regression on those paths
- [ ] Verify deprecation warning fires when `cluster_split_level != 0` is passed (call site: `clustering/mod.rs:61`)

## Notes for reviewer

- Short-term patch by design. Long-term algorithm rework is out of scope and called out in the spec's "Long-Term Considerations" section.
- Antimeridian handling for cells crossing ±180° lon is NOT addressed — flagged in the spec as a known limitation.
- `BYTE` and `BYTES_PER_CANDIDATE` both equal 1024 today but are intentionally decoupled (different semantics) so they can diverge later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)